### PR TITLE
docs: Community Membership roles, requirements, & responsibilities

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,0 +1,30 @@
+---
+name: Organization Membership Request
+about: Request membership in a Argoproj Org
+title: 'REQUEST: New membership for <your-GH-handle>'
+labels: area/github-membership
+assignees: ''
+
+---
+
+### GitHub Username
+e.g. (at)example_user
+
+### Organization you are requesting membership in
+e.g. (at)argoproj
+
+### Requirements
+- [ ] I have reviewed the community membership guidelines (https://github.com/argoproj/argoproj/blob/master/community/membership.md)
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I am actively contributing to 1 or more Argoproj subprojects
+- [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to the Argoproj project
+- PRs reviewed / authored
+- Issues responded to
+- Projects I am involved with

--- a/community/GOVERNANCE.md
+++ b/community/GOVERNANCE.md
@@ -2,28 +2,17 @@
 
 Describes the roles and responsibilities and governing structure of the Argo Community.
 
-## Community Roles and Responsibilities
-
-| Roles        | Responsibilities| Requirements  | Recognized by|
-| -------------|:---------------|:-------------|:-------------|
-| Member       | Active contributor |Active contributor |Argo GitHub org member|
-| Reviewer     | Review PRs and proposals     |   History of review and authorship |OWNERS file reviewer entry|
-| Approver     | Approve and accept PRs     |   Highly experienced, active reviewer and contributor |OWNERS file approver entry|
-| Owner        | Set priorities, approve proposals| Demonstrated responsibility and good judgement|Member of Argo TOC|
-
-* Roles are periodically reviewed and assigned by Approvers.
-* Members may also review PRs and proposals.
-* Reviewers have a responsibility to regularly review PRs and proposals in a timely
-manner.
-* Approvers may commit changes.
-* Owners provide technical leadership and are responsible for making project-level decisions in consultation with other members and the TOC.
-
 ## Technical Oversight Committee
 
-The Argo Technical Oversight Committee (TOC) is responsible for cross-cutting product and design decisions. The membership of the TOC consists of owners of the Argo projects and technical representatives from the steering committee.
+The Argo Technical Oversight Committee (TOC) is responsible for cross-cutting product and design decisions. The membership of the TOC consists of leads of the Argo projects and technical representatives from the steering committee.
 
 ## Steering Committee
 
 The Argo Steering Committee provides high-level guidance regarding the overall direction of the project and relative priority of use cases.
 Representation on the steering committee is commensurate to contributions and are selected to represent the interests of the major users and contributors of the Argo Project.
 New steering committee members are approved by the current members of the steering committee.
+
+# Community Membership
+
+See [Community Membership](membership.md) for documentation detailing the roles, responsibilities,
+and requirements of membership within the Argo project.

--- a/community/README.md
+++ b/community/README.md
@@ -18,7 +18,7 @@ Most of the community discussions happen in the Argo Slack organization. Please 
 
 ## Projects
 
-Argo is organized into a set of projects. Each project has at least one owner. The owner is responsible for driving the project, publishing a roadmap, organizing community meetings, publishing meeting notes, and reporting on the current status of the project.
+Argo is organized into a set of projects. Each project has at least one lead. The leads are responsible for driving the project, publishing a roadmap, organizing community meetings, publishing meeting notes, and reporting on the current status of the project.
 
 The projects are:
 
@@ -29,7 +29,7 @@ The projects are:
 
 ## Community Meetings
 
-Approvers and owners for each project are responsible for organizing regular community meetings to provide status updates and solicit feedback.
+Approvers and leads for each project are responsible for organizing regular community meetings to provide status updates and solicit feedback.
 
 * Meeting agendas should be published at least one week prior to the meeting.
 * Community members should be able to attend the meetings remotely.

--- a/community/membership.md
+++ b/community/membership.md
@@ -1,0 +1,286 @@
+# Community Membership
+
+This document outlines the various responsibilities of contributor roles in
+Argoproj. The Argo project is currently subdivided into four main subprojects:
+
+* [Argo Workflows](https://github.com/argoproj/argo)
+* [Argo CD](https://github.com/argoproj/argo-cd)
+* [Argo Events](https://github.com/argoproj/argo-events)
+* [Argo Rollouts](https://github.com/argoproj/argo-rollouts)
+
+Responsibilities for roles are scoped to these subprojects.
+
+| Roles        | Responsibilities| Requirements  | Defined by|
+| -------------|:---------------|:-------------|:-------------|
+| member       | active contributor in the community | sponsored by 2 approvers or leads. multiple contributions to the project. | Argoproj GitHub org member|
+| reviewer     | review contributions from other members | sponsored by a lead. history of review and authorship in a subproject | OWNERS file reviewer entry|
+| approver     | approve accepting contributions     | sponsored by a lead. highly experienced and active reviewer + contributor to a subproject  | OWNERS file approver entry |
+| lead         | set direction and priorities for a subproject | demonstrated responsibility and excellent technical judgement for the subproject | Member of Argo TOC |
+
+
+
+## New contributors
+
+New contributors should be welcomed to the community by existing members,
+helped with PR workflow, and directed to relevant documentation and
+communication channels.
+
+
+
+## Established community members
+
+Established community members are expected to demonstrate their adherence to the
+principles in this document, familiarity with project organization, roles,
+policies, procedures, conventions, etc., and technical and/or writing ability.
+Role-specific expectations, responsibilities, and requirements are enumerated
+below.
+
+
+
+## Member
+
+Members are continuously active contributors in the community. They can have issues and PRs 
+assigned to them. Members are expected to remain active contributors to the community.
+
+Defined by: Member of the Argoproj GitHub organization
+
+### Requirements
+
+- Enabled [two-factor authentication] on their GitHub account
+- Have made multiple contributions to the project or community.  Contribution may include, but is not limited to:
+    - Authoring or reviewing PRs on GitHub
+    - Filing or commenting on issues on GitHub
+    - Contributing to SIG, subproject, or community discussions (e.g. meetings, Slack, email discussion
+      forums, Stack Overflow)
+- Actively contributing to 1 or more subprojects.
+- Sponsored by 2 approvers or leads. **Note the following requirements for sponsors**:
+    - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating
+      on issues, etc.
+    - Sponsors must be approvers in at least 1 OWNERS file either in any of the four main subprojects in the [Argoproj org].
+      - An approver in the [Argoproj org] may sponsor someone for the [Argoproj org]
+      or any of the related [Argoproj GitHub organizations]; as long as it's a project they're involved with.
+      - A sponsor who is an approver in any of the related [Argoproj GitHub organizations]
+      but not in the [Argoproj org] can only sponsor someone for the orgs they are associated with.
+    - Sponsors must be from multiple member companies to demonstrate integration across community.
+- **[Open an issue][membership request] against the argoproj/argoproj repo**
+   - Ensure your sponsors are @mentioned on the issue
+   - Complete every item on the checklist ([preview the current version of the template][membership template])
+   - Make sure that the list of contributions included is representative of your work on the project.
+- Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+- Once your sponsors have responded, your request will be reviewed by the Argoproj GitHub Admin team. Any missing information will be requested.
+
+### Responsibilities and privileges
+
+- Responsive to issues and PRs assigned to them
+- Responsive to mentions of subprojects they are members of
+- Active owner of code they have contributed (unless ownership is explicitly transferred)
+  - Code is well tested
+  - Tests consistently pass
+  - Addresses bugs or issues discovered after code is accepted
+- Members are welcome and encouraged to review PRs and proposals.
+- They can be assigned to issues and PRs, and people can ask members for reviews with a `/cc @username`.
+
+**Note:** members who frequently contribute code are expected to proactively
+perform code reviews and work towards becoming a primary *reviewer* for the
+subproject that they are active in.
+
+
+
+## Reviewer
+
+Reviewers are able to review code for quality and correctness on some part of a
+subproject. They are knowledgeable about both the codebase and software
+engineering principles.
+
+**Defined by:** *reviewers* entry in an OWNERS file in a repo owned by the
+Argoproj project.
+
+Reviewer status is scoped to a part of the codebase.
+
+**Note:** Acceptance of code contributions requires at least one approver in
+addition to the assigned reviewers.
+
+### Requirements
+
+The following apply to the part of codebase for which one would be a reviewer in
+an `OWNERS` file.
+
+- Member for at least 3 months
+- Active community participation (meetings, slack, stack overflow) and interact with issues for at least 1 month.
+- Primary reviewer for at least 5 PRs to the codebase
+- Reviewer for or author of at least 5 substantial PRs to the codebase, with the
+  definition of substantial subject to the lead's discretion (e.g.
+  refactors, enhancements rather than grammar correction or one-line pulls).
+- Knowledgeable about the codebase
+- Sponsored by a subproject lead
+  - With no objections from other leads
+  - Done through PR to update the OWNERS file
+- May either self-nominate, be nominated by an approver in the subproject
+
+### Responsibilities and privileges
+
+The following apply to the part of codebase for which one would be a reviewer in
+an `OWNERS` file.
+
+- Respond to new PRs and Issues by asking clarifying questions
+- Organize the backlog by applying labels, milestones, assignees, and projects
+- Code reviewer status may be a precondition to accepting large code contributions
+- Responsible for project quality control via code reviews
+  - Focus on code quality and correctness, including testing and factoring
+  - May also review for more holistic issues, but not a requirement
+- Expected to be responsive to review requests
+- Assigned PRs to review related to subproject of expertise
+- Assigned test bugs related to subproject of expertise
+
+
+
+## Approver
+
+Code approvers are able to both review and approve code contributions as well as 
+help subproject leads triage issues and with project management.
+
+While code review is focused on code quality and correctness, approval is focused on
+holistic acceptance of a contribution including: backwards / forwards
+compatibility, adhering to API and flag conventions, subtle performance and
+correctness issues, interactions with other parts of the system, etc.
+
+**Defined by:** *approvers* entry in an OWNERS file in a repo owned by the
+Argoproj project.
+
+Approver status is scoped to a part of the codebase.
+
+### Requirements
+
+The following apply to the part of codebase for which one would be an approver
+in an `OWNERS` file.
+
+- Reviewer for at least 3 months
+- Reviewer for or author of at least 10 substantial PRs to the codebase, with the
+  definition of substantial subject to the lead's discretion (e.g.
+  refactors, enhancements rather than grammar correction or one-line pulls).
+- Sponsored by a subproject lead
+  - With no objections from other leads
+  - Done through PR to update the OWNERS file
+
+### Responsibilities and privileges
+
+The following apply to the part of codebase for which one would be an approver
+in an `OWNERS` file.
+
+- Approver status may be a precondition to accepting large code contributions
+- Demonstrate sound technical judgement
+- Responsible for project quality control via code reviews
+  - Focus on holistic acceptance of contribution such as dependencies with other features, backwards / forwards
+    compatibility, API and flag definitions, etc
+- Expected to be responsive to review requests (inactivity may result in suspension until active again)
+- Mentor contributors and reviewers
+- May approve and merge code contributions for acceptance
+
+
+
+## Lead
+
+Subproject Leads are the technical authority for a subproject in the Argo
+project.  They *MUST* have demonstrated both good judgement and responsibility
+towards the health of that subproject.  Subproject leads *MUST* set technical
+direction and make or approve design decisions for their subproject - either
+directly or through delegation of these responsibilities.
+
+**Defined by:** *leads* entry in subproject `OWNERS` files
+
+### Requirements
+
+The process for becoming an subproject lead should be defined in the SIG
+charter of the SIG owning the subproject.  Unlike the roles outlined above, the
+Leads of a subproject are typically limited to a relatively small group of
+decision makers and updated as fits the needs of the subproject.
+
+The following apply to the subproject for which one would be an lead.
+
+- Deep understanding of the technical goals and direction of the subproject
+- Deep understanding of the technical domain of the subproject
+- Sustained contributions to design and direction by doing all of:
+  - Authoring and reviewing proposals
+  - Initiating, contributing and resolving discussions (emails, GitHub issues, meetings)
+  - Identifying subtle or complex issues in designs and implementation PRs
+- Directly contributed to the subproject through implementation and / or review
+
+### Responsibilities and privileges
+
+The following apply to the subproject for which one would be an lead.
+
+- Make and approve technical design decisions for the subproject.
+- Set technical direction and priorities for the subproject.
+- Define milestones and releases.
+  - Decides on when PRs are merged to control the release scope.
+- Mentor and guide approvers, reviewers, and contributors to the subproject.
+- Escalate reviewer and maintainer concerns (i.e. responsiveness, availability, and general contributor community health) to the TC.
+- Ensure continued health of subproject
+  - Adequate test coverage to confidently release
+  - Tests are passing reliably (i.e. not flaky) and are fixed when they fail
+- Ensure a healthy process for discussion and decision making is in place.
+- Work with other subproject leads to maintain the project's overall health and success holistically
+
+
+
+## Inactive members
+
+_Members are continuously active contributors in the community._
+
+A core principle in maintaining a healthy community is encouraging active
+participation. It is inevitable that people's focuses will change over time and
+they are not expected to be actively contributing forever.
+
+However, being a member of one of the Argoproj GitHub organizations comes with
+an [elevated set of permissions]. These capabilities should not be used by those
+that are not familiar with the current state of the Argo project.
+
+Therefore members with an extended period away from the project with no activity
+will be removed from the Argoproj Github Organizations and will be required to
+go through the org membership process again after re-familiarizing themselves
+with the current state.
+
+
+### How inactivity is measured
+
+Inactive members are defined as members of one of the Argoproj Organizations
+with **no** contributions across any organization within 12 months. This is
+measured by the CNCF [DevStats project].
+
+**Note:** Devstats does not take into account non-code contributions. If a
+non-code contributing member is accidentally removed this way, they may open an
+issue to quickly be re-instated. 
+
+After an extended period away from the project with no activity
+those members would need to re-familiarize themselves with the current state
+before being able to contribute effectively. 
+
+
+## Argoproj Ecosystem
+
+There are related [Argoproj GitHub organizations], such as [argoproj-labs].
+If you are a Argoproj org member, you are implicitly eligible
+for membership in related orgs, and can request membership when it becomes
+relevant, by creating a PR directly or [opening an issue][membership request]
+against the argoproj/argoproj repo, as above.
+
+However, if you are a member of any of the related
+[Argoproj GitHub organizations] but not of the [Argoproj org],
+you will need explicit sponsorship for your membership request.
+
+### Actively used GitHub Organizations
+
+| Name | Description |
+| :--: | :---------: |
+| [argoproj](https://github.com/argoproj) | Core Argo Projects and supporting projects |
+| [argoproj-labs](https://github.com/argoproj-labs) | Experimental and ecosystem projects |
+
+
+[Argoproj GitHub organizations]: #actively-used-github-organizations
+[Argoproj org]: https://github.com/argoproj
+[argoproj-labs]: ttps://github.com/argoproj-labs
+[membership request]: https://github.com/argoproj/argoproj/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E
+[membership template]: https://github.com/argoproj/argoproj/blob/master/.github/ISSUE_TEMPLATE/membership.md
+[two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
+[elevated set of permissions]: #Responsibilities-and-privileges
+[Devstats project]: https://argo.devstats.cncf.io/

--- a/community/membership.md
+++ b/community/membership.md
@@ -67,7 +67,7 @@ Defined by: Member of the Argoproj GitHub organization
    - Complete every item on the checklist ([preview the current version of the template][membership template])
    - Make sure that the list of contributions included is representative of your work on the project.
 - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-- Once your sponsors have responded, your request will be reviewed by the Argoproj GitHub Admin team. Any missing information will be requested.
+- Once your sponsors have responded, your request will be reviewed by the project leads. Any missing information will be requested.
 
 ### Responsibilities and privileges
 
@@ -100,6 +100,10 @@ Reviewer status is scoped to a part of the codebase.
 **Note:** Acceptance of code contributions requires at least one approver in
 addition to the assigned reviewers.
 
+While these guidelines are going to be used for setting contribution expectations, 
+the maintainers will recognize the impact of an individual's contribution while 
+making a decision on promotion an individual to a "reviewer."
+
 ### Requirements
 
 The following apply to the part of codebase for which one would be a reviewer in
@@ -107,7 +111,6 @@ an `OWNERS` file.
 
 - Member for at least 3 months
 - Active community participation (meetings, slack, stack overflow) and interact with issues for at least 1 month.
-- Primary reviewer for at least 5 PRs to the codebase
 - Reviewer for or author of at least 5 substantial PRs to the codebase, with the
   definition of substantial subject to the lead's discretion (e.g.
   refactors, enhancements rather than grammar correction or one-line pulls).
@@ -220,6 +223,7 @@ The following apply to the subproject for which one would be an lead.
   - Tests are passing reliably (i.e. not flaky) and are fixed when they fail
 - Ensure a healthy process for discussion and decision making is in place.
 - Work with other subproject leads to maintain the project's overall health and success holistically
+- Promote and foster the community (e.g. hosting meetings, workshops, partner engagements, collaborations)
 
 
 
@@ -278,7 +282,7 @@ you will need explicit sponsorship for your membership request.
 
 [Argoproj GitHub organizations]: #actively-used-github-organizations
 [Argoproj org]: https://github.com/argoproj
-[argoproj-labs]: ttps://github.com/argoproj-labs
+[argoproj-labs]: https://github.com/argoproj-labs
 [membership request]: https://github.com/argoproj/argoproj/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E
 [membership template]: https://github.com/argoproj/argoproj/blob/master/.github/ISSUE_TEMPLATE/membership.md
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication


### PR DESCRIPTION
Document Argo Project community membership roles, requirements, & responsibilities. This was adapted from the Kubernetes community membership doc, as well as the open telemetry community membership doc (which was copied from kubernetes).