### PR TITLE
feat: members should have ability to moderate github discussions

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -71,6 +71,7 @@ Defined by: Member of the Argoproj GitHub organization
 
 ### Responsibilities and privileges
 
+- Have the ability to moderate GitHub discussions
 - Responsive to issues and PRs assigned to them
 - Responsive to mentions of subprojects they are members of
 - Active owner of code they have contributed (unless ownership is explicitly transferred)


### PR DESCRIPTION
As discussed in today's contributor's meeting today, it was proposed to allow Argoproj members to moderate GitHub discussions (e.g. mark answers as accepted) to help share the load of answering questions from the community.

Signed-off-by: Jesse Suen <jessesuen@gmail.com>