### PR TITLE
Broken link Fix

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -39,7 +39,7 @@ within 24 hours of the meeting.
 
 ## Contributing to Argo
 
-Read and abide by the [Argo Code of Conduct](https://github.com/argoproj/argo/blob/master/CODE_OF_CONDUCT.md).
+Read and abide by the [Argo Code of Conduct](https://github.com/argoproj/community-contrib-docs/tree/3b76affa356dbc3160b31f9a96ac81dfa49017ae).
 
 Argo Project uses the DCO.
 * https://github.com/apps/dco/


### PR DESCRIPTION
Code of Conduct Link is broken
You can see the issue from the screenshot attached below: 

<img width="450" alt="error" src="https://user-images.githubusercontent.com/63901956/126888045-0c1de4d3-7ca1-46bf-a321-9f03621c5c34.png">

Fixed it with the right address, below: 
https://github.com/argoproj/community-contrib-docs/tree/3b76affa356dbc3160b31f9a96ac81dfa49017ae
