### PR TITLE
docs: Update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ respective code repositories:
 
 * [Security Policy for Argo Workflows](https://github.com/argoproj/argo-workflows/blob/master/SECURITY.md)
 * [Security Policy for Argo Events](https://github.com/argoproj/argo-events/blob/master/SECURITY.md)
-* [Security Policy for Argo Rollouts](https://github.com/argoproj/argo-rollouts/blob/master/SECURITY.md)
+* [Security Policy for Argo Rollouts](https://github.com/argoproj/argo-rollouts/blob/master/docs/security.md)
 * [Security Policy for Argo CD](https://github.com/argoproj/argo-cd/blob/master/SECURITY.md)
 
 ## Reporting Vulnerabilities

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,37 @@
-# Security 
+# Security Policy for Argo projects
+
+Version **v1.1 (2020-08-08)**
+
+## Preface
+
+The security policy in `argoproj/argoproj` acts as a proxy policy for the Argo
+sub-projects
+[Argo Workflows](https://github.com/argoproj/argo-workflows),
+[Argo Events](https://github.com/argoproj/argo-events),
+[Argo Rollouts](https://github.com/argoproj/argo-rollouts) and
+[Argo CD](https://github.com/argoproj/argo-cd),
+
+For more specific policies, please refer to the following documents in their
+respective code repositories:
+
+* [Security Policy for Argo Workflows](https://github.com/argoproj/argo-workflows/blob/master/SECURITY.md)
+* [Security Policy for Argo Events](https://github.com/argoproj/argo-events/blob/master/SECURITY.md)
+* [Security Policy for Argo Rollouts](https://github.com/argoproj/argo-rollouts/blob/master/SECURITY.md)
+* [Security Policy for Argo CD](https://github.com/argoproj/argo-cd/blob/master/SECURITY.md)
 
 ## Reporting Vulnerabilities
 
-Please report security vulnerabilities by e-mailing:
+In general, we kindly ask you for responsible disclosure of any security
+vulnerabilities you may have found in one of our projects. Please do not create
+a GitHub issue, but instead contact us via e-mail at the following address:
 
-* [Jesse_Suen@intuit.com](mailto:Jesse_Suen@intuit.com)
-* [Alex_Collins@intuit.com](mailto:Alex_Collins@intuit.com)
-* [Edward_Lee@intuit.com](mailto:Edward_Lee@intuit.com)
+* cncf-argo-security@lists.cncf.io
+
+We also kindly ask you to allow us some time for analysing the report and react
+on it. We will get in contact with you as soon as possible.
 
 ## Public Disclosure
 
-Security vulnerabilities will be disclosed via [release notes](docs/releasing.md).
-
-## Vulnerability Scanning
-
-See [static code analysis](static-code-analysis.md).
+Please refer to the sub-projects' dedicated security policies (see above) for
+specific details on how we handle reported vulnerabilities, public disclosure,
+crediting and other information.


### PR DESCRIPTION
This updates the proxy security policy to a more sensible version, and also updates the e-mail contacts.

Link to 

Signed-off-by: jannfis <jann@mistrust.net>