### PR TITLE
feat: expand permissions of members to include Triage capability

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -40,7 +40,9 @@ below.
 ## Member
 
 Members are continuously active contributors in the community. They can have issues and PRs 
-assigned to them. Members are expected to remain active contributors to the community.
+assigned to them. Members are expected to remain active contributors to the community. Members are
+given the [Triage](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization) GitHub role to Argoproj repositories, in order to
+facilitate issue management and moderate discussions.
 
 Defined by: Member of the Argoproj GitHub organization
 
@@ -72,6 +74,7 @@ Defined by: Member of the Argoproj GitHub organization
 ### Responsibilities and privileges
 
 - Have the ability to moderate GitHub discussions
+- Have the ability to triage GitHub issues through labeling
 - Responsive to issues and PRs assigned to them
 - Responsive to mentions of subprojects they are members of
 - Active owner of code they have contributed (unless ownership is explicitly transferred)


### PR DESCRIPTION
Discussed and agreed in both the Argoproj contributors meeting as well as maintainers meeting on 8/12 and 8/13 respectively, we would like to expand the privileges of all Argoproj members such that they can triage (label) issues and moderate GitHub discussions. This involves the following changes:

1. Creation of a "members" GitHub team. All members of the Argoproj and Argoproj-labs organization will also be members of the "members" GitHub team.
2. For all public git repositories in argoproj and argoproj-labs, the "members" GitHub team will be added to the repository with the "Triage" role. This needs to be done per repository, as there is no automatic way to do this in GitHub.

For additional details on what the Triage role is able to do, see [GitHub documentation](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization)

This PR is for the maintainers to affirm these changes.

Please vote by adding a +1/-1 and indicate whether your vote is binding (maintainer) or non-binding (community).
Non-binding votes by the community are encouraged!

This vote will close in two weeks, on Wednesday, September 1st, at 11.59 pm Pacific Time, or with 2/3 supermajority vote, whichever comes first.

Signed-off-by: Jesse Suen <jessesuen@gmail.com>