### PR TITLE
docs: Add caelan and jp as members

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,3 +44,5 @@
 | Saumeya Katyal | [saumeya](https://github.com/saumeya) | Reviewer - CD | [Red Hat](https://www.github.com/redhat/) | Yes |
 | Yi Cai | [ciiay](https://github.com/ciiay) | Reviewer - CD | [Red Hat](https://www.github.com/redhat/) | Yes |
 | Hui Kang | [huikang](https://github.com/huikang) | Approver - Rollouts | [Salesforce](https://salesforce.com/) | Yes |
+| J.P.Zivalich | [JPZ13](https://github.com/JPZ13) | Member - Workflows | [Pipekit](https://pipekit.io/) | No |
+| Caelan Urquhart | [caelan-io](https://github.com/caelan-io) | Member - Workflows | [Pipekit](https://pipekit.io/) | No |


### PR DESCRIPTION
@alexec mentioned that @caelan-io and I should apply for membership. Not sure if the `MAINTAINERS.md` doc is the right place to do it but wanted to get the ball rolling
Signed-off-by: J.P. Zivalich <jp@pipekit.io>