### PR TITLE
docs: add security disclaimer and requirement for argoproj-labs projects

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ respective code repositories:
 
 ### Argoproj Labs
 
-The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and have different security practices than the four Argo sub-projects. All labs projects are required to have a `SECURITY.md` documenting their security policies as well as listing their security contacts for reporting vulnerabilities. 
+The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and may have different security practices than the four Argo sub-projects. All Labs projects are required to have a `SECURITY.md` in the root of their repository documenting their security policies as well as listing security contacts for reporting vulnerabilities. 
 
 ## Reporting Vulnerabilities
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,9 @@
 # Security Policy for Argo projects
 
-Version **v1.1 (2020-08-08)**
+Versions:
+* v1.2 (2022-03-22) - Add Argoproj-labs disclaimer
+* v1.1 (2021-08-08) - Update contacts
+* v1.0 (2020-04-30) - Initial version
 
 ## Preface
 
@@ -19,6 +22,10 @@ respective code repositories:
 * [Security Policy for Argo Rollouts](https://github.com/argoproj/argo-rollouts/blob/master/docs/security.md)
 * [Security Policy for Argo CD](https://github.com/argoproj/argo-cd/blob/master/SECURITY.md)
 
+### Argoproj Labs
+
+The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and have different security practices than the four Argo sub-projects. All labs projects are required to have a `SECURITY.md` documenting their security policies as well as listing their security contacts for reporting vulnerabilities. 
+
 ## Reporting Vulnerabilities
 
 In general, we kindly ask you for responsible disclosure of any security
@@ -26,6 +33,8 @@ vulnerabilities you may have found in one of our projects. Please do not create
 a GitHub issue, but instead contact us via e-mail at the following address:
 
 * cncf-argo-security@lists.cncf.io
+
+For reporting vulnerabilities to projects under Argoproj Labs, please visit the project's `SECURITY.md` policy to reach the correct contacts.
 
 We also kindly ask you to allow us some time for analysing the report and react
 on it. We will get in contact with you as soon as possible.

--- a/community/ecosystem-projects.md
+++ b/community/ecosystem-projects.md
@@ -43,6 +43,16 @@ The good examples are:
 
 ## Requirements
 
+### Security
+
+All Argoproj Labs projects must contain a `SECURITY.md` file documenting:
+* Contacts or mailing list for reporting vulnerabilities
+* Details about the project security policies
+
+In the future, we may require each project perform self-assessment on what best practices are followed, such as the [CII badge](https://bestpractices.coreinfrastructure.org/en).
+
+### Container Registry
+
 Since projects under Argoproj labs are considered experimental and/or opinionated enhancements,
 container images shall be housed under a separate container registry separate from quay.io/argoproj,
 under [quay.io/argoprojlabs](https://quay.io/organization/argoprojlabs).


### PR DESCRIPTION
This change adds a security disclaimer about argoproj-labs projects and also requires all labs project have a SECURITY.md which lists contacts for reporting vulnerabilities.

Signed-off-by: Jesse Suen <jesse@akuity.io>