### PR TITLE
Argoproj promotions/membership

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,10 +21,10 @@
 | Keith Chong| [keithchong](https://github.com/keithchong) | Approver - CD | [Red Hat](https://www.github.com/redhat/) |
 | Alex Collins| [alexec](https://github.com/alexec) | Lead - Workflows <br/>Approver - CD  | [Intuit](https://www.github.com/intuit/) |
 | Michael Crenshaw | [crenshaw-dev](https://github.com/crenshaw-dev) | Approver - CD | [Intuit](https://www.github.com/intuit/) |
+| Alex Eftimie | [alexef](https://github.com/alexef) | Reviewer - CD | [GetYourGuide](https://www.getyourguide.com/) |
 | Jann Fischer| [jannfis](https://github.com/jannfis) | Approver - CD | [Red Hat](https://www.github.com/redhat/) |
 | Dan Garfield| [todaywasawesome](https://github.com/todaywasawesome) | Reviewer | [Codefresh](https://www.github.com/codefresh/) |
 | Ravi Hari | [RaviHari](https://github.com/RaviHari) | Reviewer - Rollouts | [Intuit](https://www.github.com/intuit/) |
-| Kareena Hirani| [khhirani](https://github.com/khhirani) | Approver - Rollouts | Independent |
 | Hui Kang | [huikang](https://github.com/huikang) | Approver - Rollouts | [Salesforce](https://salesforce.com/) |
 | Saumeya Katyal | [saumeya](https://github.com/saumeya) | Reviewer - CD | [Red Hat](https://www.github.com/redhat/) |
 | Kostis Kapelonis | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts | [Codefresh](https://www.github.com/codefresh/) |
@@ -42,7 +42,6 @@
 | Jesse Suen | [jessesuen](https://github.com/jessesuen) | Lead - CD, Rollouts <br/>Approver - Workflows, Events | [Akuity](https://akuity.io/) |
 | Yuan Tang| [terrytangyuan](https://github.com/terrytangyuan) | Approver - Workflows <br/>Reviewer - CD | [Akuity](https://akuity.io/) |
 | William Tam | [wtam2018](https://github.com/wtam2018) | Reviewer - CD | [Red Hat](https://www.github.com/redhat/) |
-| Daisuke Taniwaki| [dtaniwaki](https://github.com/dtaniwaki) | Approver - Workflows, Events | [Ubie](https://ubie.life/) |
 | Julie Vogelman | [juliev0](https://github.com/juliev0) | Reviewer - Workflows | [Intuit](https://www.github.com/intuit/) |
 | Derek Wang | [whynowy](https://github.com/whynowy) | Lead - Events | [Intuit](https://www.github.com/intuit/) |
 | Hong Wang | [wanghong230](https://github.com/wanghong230) | Reviewer | [Akuity](https://akuity.io/) |
@@ -55,3 +54,5 @@
 | Alumni | GitHub ID | Project Roles | Affiliation
 | --------------- | --------- | ----------- | ----------- |
 | Xianlu Chen | [xianlubird](https://github.com/xianlubird) | Reviewer - Workflows | [Alibaba Cloud](https://github.com/aliyun) |
+| Kareena Hirani| [khhirani](https://github.com/khhirani) | Approver - Rollouts | Independent |
+| Daisuke Taniwaki| [dtaniwaki](https://github.com/dtaniwaki) | Approver - Workflows, Events | [Ubie](https://ubie.life/) |


### PR DESCRIPTION
# Argoproj promotions/membership

Every quarter, the Argoproj maintainers review requests for project membership and promotions (read about the roles [here](https://github.com/argoproj/argoproj/blob/master/community/membership.md#community-membership)). The changes below recognize the incredible efforts ([graphed on CNCF devstats](https://argo.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&var-period=w&var-metric=contributions&var-repogroup_name=All&var-users=%22morey-tech%22&var-users=%22alexef%22&var-users=%22jaideepr97%22&var-users=%22jmeridth%22&from=now-6M&to=now)) and commitment to the project by these four people. Thank you so much!

## 🚀  Maintainer promotions

Congrats to Alex Eftimie (@alexef) on their promotion to Reviewer for Argo CD!

## ⭐  New members

An additional congratulations to the following folks for becoming Argoproj members:

* @jaideepr97
* @jmeridth
* @morey-tech

You all will receive invitations on GitHub to become members of the Argoproj organization.

## 🎓 Alumni

The maintainers document contains a new section for folks who were previously maintainers but have been inactive for at least a year. While not currently active, they deserve continued recognition for their impact on the project!

Closes https://github.com/argoproj/argoproj/issues/177
Closes https://github.com/argoproj/argoproj/issues/179
Closes https://github.com/argoproj/argoproj/issues/180
Closes https://github.com/argoproj/argoproj/issues/185