### PR TITLE
docs: markdownify links in membership template

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -12,8 +12,8 @@ assignees: ''
 @<your-GH-handle>
 
 ### Requirements
-- [ ] I have reviewed the community membership guidelines (https://github.com/argoproj/argoproj/blob/master/community/membership.md)
-- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I have reviewed [the community membership guidelines](https://github.com/argoproj/argoproj/blob/master/community/membership.md)
+- [ ] I have [enabled 2FA on my GitHub account](https://github.com/settings/security)
 - [ ] I am actively contributing to 1 or more Argoproj subprojects
 - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
 - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application


### PR DESCRIPTION
### Motivation

- figured this looks a little nicer once the issue is created and in preview mode
- stumbled upon this while filing for my own membership in #221 😅

### Changes

- Convert the parenthesized links in the membership template to Markdown links

See [GH Preview](https://github.com/argoproj/argoproj/blob/b87c02a1e550fc2b0590c79c4b71b2c656b6a870/.github/ISSUE_TEMPLATE/membership.md)