### PR TITLE
docs: be specific about the permissions of Members

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -73,8 +73,12 @@ Defined by: Member of the Argoproj GitHub organization
 
 ### Responsibilities and privileges
 
-- Have the ability to moderate GitHub discussions
-- Have the ability to triage GitHub issues through labeling
+- Have the ability to _moderate_ GitHub discussions
+  - This includes editing and hiding comments, labeling and closing discussions, and selecting an answer (when applicable)
+  - This does _not_ include editing the opening comment
+- Have the ability to _triage_ GitHub issues and pull requests
+  - This includes labeling, closing or re-opening, adding to projects, assigning, and adding reviewers
+  - This does _not_ include editing or hiding comments nor creating, deleting, or modifying labels or projects themselves
 - Responsive to issues and PRs assigned to them
 - Responsive to mentions of subprojects they are members of
 - Active owner of code they have contributed (unless ownership is explicitly transferred)


### PR DESCRIPTION
## Motivation

- there are some "triage-level" permissions that I thought I would have but apparently don't, so wanted to document those more explicitly
  - which should hopefully result in more clarity / less ambiguity / less confusion amongst the community, especially Member+

## Modifications

- Discussions and Issues vs. PR permissions differ fairly significantly
  - can't hide or edit issue or PR comments, which I often do as part of triage etc
  - but can do so in discussions
    - but can't do so on the opening comment of a discussion (which may be missing syntax highlighting, have spelling or grammatical errors, etc)
- Have [learned](https://cloud-native.slack.com/archives/C0510EUH90V/p1692120705627719) that I can't add labels nor modify existing labels
  - it is often useful to [create new labels](https://cloud-native.slack.com/archives/C0510EUH90V/p1692641716347669) as part of triage if I start to see a pattern that doesn't fit an existing label
    - I make pretty heavy usage of labels for filtering and triage purposes in other repos I maintain: [example](https://github.com/ezolenko/rollup-plugin-typescript2/labels)
  - some labels also had inconsistent coloring or lacked a description, and I similarly had no permission to change those