### PR TITLE
feat: make argo-helm a pseudo-project

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,22 +9,18 @@
 | Maintainer                | GitHub ID                                               | Project Roles                                         | Affiliation                                     |
 |---------------------------|---------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------|
 | Rohit Agrawal             | [agrawroh](https://github.com/agrawroh)                 | Reviewer - Rollouts                                   | [Databricks](https://databricks.com/)           |
-| Aikawa                    | [yu-croco](https://github.com/yu-croco)                 | Approver - Helm (Workflows)                           |                                                 |
 | Zach Aller                | [zachaller](https://github.com/zachaller)               | Lead - Rollouts <br/>Reviewer - CD                    | [Intuit](https://www.github.com/intuit/)        |
 | Leonardo Luz Almeida      | [leoluz](https://github.com/leoluz)                     | Approver - CD, Rollouts                               | [Intuit](https://www.github.com/intuit/)        |
 | Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Lead - Workflows                                      | [Intuit](https://www.github.com/intuit/)        |
 | Chetan Banavikalmutt      | [chetan-rns](https://github.com/chetan-rns)             | Reviewer - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
-| Marko Bevc                | [mbevc1](https://github.com/mbevc1)                     | Approver - Helm (CD)                                  | [Red Hat](https://www.github.com/redhat/)       |
 | Henrik Blixt              | [hblixt](https://github.com/hblixt)                     | Reviewer                                              | [Intuit](https://www.github.com/intuit/)        |
 | Shoubhik Bose             | [sbose78](https://github.com/sbose78)                   | Reviewer                                              | [Red Hat](https://www.github.com/redhat/)       |
 | Remington Breeze          | [rbreeze](https://github.com/rbreeze)                   | Approver CD, Rollouts                                 | [Akuity](https://akuity.io/)                    |
 | Yi Cai                    | [ciiay](https://github.com/ciiay)                       | Reviewer - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD               | [Intuit](https://www.github.com/intuit/)        |
-| Tim Collins               | [tico24](https://github.com/tico24)                     | Approver - Helm (CD, Events, Workflows)               | [Pipekit](https://pipekit.io)                   |
 | Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Approver - CD                                         | [Intuit](https://www.github.com/intuit/)        |
 | Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Reviewer - CD                                         | [Akuity](https://akuity.io/)                    |
-| Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Approver - Helm (CD, Events)                          | Independent                                     |
 | Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                         | [GetYourGuide](https://www.getyourguide.com/)   |
 | Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                   | [Codefresh](https://www.github.com/codefresh/)  |
@@ -34,7 +30,6 @@
 | Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                   | [Codefresh](https://www.github.com/codefresh/)  |
 | Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                         | [Codefresh](https://www.github.com/codefresh/)  |
 | Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                          | [Intuit](https://www.github.com/intuit/)        |
-| Vlad Losev                | [vladlosev](https://github.com/vladlosev)               | Approver - Helm (Workflows)                           |                                                 |
 | Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                | [Akuity](https://akuity.io/)                    |
 | Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows         | [Akuity](https://akuity.io/)                    |
 | Marco Maurer              | [mkilchhofer](https://github.com/mkilchhofer)           | Lead - Helm                                           | [Swiss Post](https://www.github.com/swisspost)  |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,18 +9,22 @@
 | Maintainer                | GitHub ID                                               | Project Roles                                         | Affiliation                                     |
 |---------------------------|---------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------|
 | Rohit Agrawal             | [agrawroh](https://github.com/agrawroh)                 | Reviewer - Rollouts                                   | [Databricks](https://databricks.com/)           |
+| Aikawa                    | [yu-croco](https://github.com/yu-croco)                 | Approver - Helm (Workflows)                           |                                                 |
 | Zach Aller                | [zachaller](https://github.com/zachaller)               | Lead - Rollouts <br/>Reviewer - CD                    | [Intuit](https://www.github.com/intuit/)        |
 | Leonardo Luz Almeida      | [leoluz](https://github.com/leoluz)                     | Approver - CD, Rollouts                               | [Intuit](https://www.github.com/intuit/)        |
 | Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Lead - Workflows                                      | [Intuit](https://www.github.com/intuit/)        |
 | Chetan Banavikalmutt      | [chetan-rns](https://github.com/chetan-rns)             | Reviewer - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
+| Marko Bevc                | [mbevc1](https://github.com/mbevc1)                     | Approver - Helm (CD)                                  | [Red Hat](https://www.github.com/redhat/)       |
 | Henrik Blixt              | [hblixt](https://github.com/hblixt)                     | Reviewer                                              | [Intuit](https://www.github.com/intuit/)        |
 | Shoubhik Bose             | [sbose78](https://github.com/sbose78)                   | Reviewer                                              | [Red Hat](https://www.github.com/redhat/)       |
 | Remington Breeze          | [rbreeze](https://github.com/rbreeze)                   | Approver CD, Rollouts                                 | [Akuity](https://akuity.io/)                    |
 | Yi Cai                    | [ciiay](https://github.com/ciiay)                       | Reviewer - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD               | [Intuit](https://www.github.com/intuit/)        |
+| Tim Collins               | [tico24](https://github.com/tico24)                     | Approver - Helm (CD, Events, Workflows)               | [Pipekit](https://pipekit.io)                   |
 | Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Approver - CD                                         | [Intuit](https://www.github.com/intuit/)        |
 | Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Reviewer - CD                                         | [Akuity](https://akuity.io/)                    |
+| Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Approver - Helm (CD, Events)                          | Independent                                     |
 | Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                         | [GetYourGuide](https://www.getyourguide.com/)   |
 | Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                         | [Red Hat](https://www.github.com/redhat/)       |
 | Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                   | [Codefresh](https://www.github.com/codefresh/)  |
@@ -30,6 +34,7 @@
 | Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                   | [Codefresh](https://www.github.com/codefresh/)  |
 | Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                         | [Codefresh](https://www.github.com/codefresh/)  |
 | Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                          | [Intuit](https://www.github.com/intuit/)        |
+| Vlad Losev                | [vladlosev](https://github.com/vladlosev)               | Approver - Helm (Workflows)                           |                                                 |
 | Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                | [Akuity](https://akuity.io/)                    |
 | Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows         | [Akuity](https://akuity.io/)                    |
 | Marco Maurer              | [mkilchofer](https://github.com/mkilchofer)             | Lead - Helm                                           | [Swiss Post](https://www.github.com/swisspost)  |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,6 +32,8 @@
 | Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                          | [Intuit](https://www.github.com/intuit/)        |
 | Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                | [Akuity](https://akuity.io/)                    |
 | Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows         | [Akuity](https://akuity.io/)                    |
+| Marco Maurer              | [mkilchofer](https://github.com/mkilchofer)             | Lead - Helm                                           | [Swiss Post](https://www.github.com/swisspost)  |
+| Jason Meridth             | [jmeridth](https://github.com/jmeridth)                 | Lead - Helm                                           | [Procore](https://www.github.com/procore)       |
 | Nicholas Morey            | [morey-tech](https://github.com/morey-tech)             | Reviewer(docs) - CD                                   | [Akuity](https://akuity.io/)                    |
 | Vaibhav Page              | [VaibhavPage](https://github.com/VaibhavPage)           | Lead - Events                                         | [Black Rock](https://www.github.com/blackrock/) |
 | Blake Pettersson          | [blakepettersson](https://github.com/blakepettersson)   | Approver(docs) - CD                                   | [Krobier](https://www.krobier.com)              |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,7 +37,7 @@
 | Vlad Losev                | [vladlosev](https://github.com/vladlosev)               | Approver - Helm (Workflows)                           |                                                 |
 | Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                | [Akuity](https://akuity.io/)                    |
 | Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows         | [Akuity](https://akuity.io/)                    |
-| Marco Maurer              | [mkilchofer](https://github.com/mkilchofer)             | Lead - Helm                                           | [Swiss Post](https://www.github.com/swisspost)  |
+| Marco Maurer              | [mkilchhofer](https://github.com/mkilchhofer)           | Lead - Helm                                           | [Swiss Post](https://www.github.com/swisspost)  |
 | Jason Meridth             | [jmeridth](https://github.com/jmeridth)                 | Lead - Helm                                           | [Procore](https://www.github.com/procore)       |
 | Nicholas Morey            | [morey-tech](https://github.com/morey-tech)             | Reviewer(docs) - CD                                   | [Akuity](https://akuity.io/)                    |
 | Vaibhav Page              | [VaibhavPage](https://github.com/VaibhavPage)           | Lead - Events                                         | [Black Rock](https://www.github.com/blackrock/) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ respective code repositories:
 
 ### Argoproj Labs
 
-The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and may have different security practices than the four Argo sub-projects. All Labs projects are required to have a `SECURITY.md` in the root of their repository documenting their security policies as well as listing security contacts for reporting vulnerabilities. 
+The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and may have different security practices than the four core Argo sub-projects. All Labs projects are required to have a `SECURITY.md` in the root of their repository documenting their security policies as well as listing security contacts for reporting vulnerabilities. 
 
 ## Reporting Vulnerabilities
 
@@ -47,7 +47,7 @@ folks over at
 [Hacker One](https://hackerone.com/) and their
 [Internet Bug Bounty program](https://hackerone.com/ibb)
 to reward the awesome people who find security vulnerabilities in the four
-main Argo projects (CD, Events, Rollouts and Workflows) and then work with
+core Argo sub-projects (CD, Events, Rollouts and Workflows) and then work with
 us to fix and disclose them in a responsible manner.
 
 If you report a vulnerability to us as outlined in this security policy, we

--- a/community/GOVERNANCE.md
+++ b/community/GOVERNANCE.md
@@ -1,5 +1,5 @@
 # Argo Governance
-This document outlines the governance for the overall Argo Project and the four sub-projects contained within.  
+This document outlines the governance for the overall Argo Project and the four core sub-projects contained within, as well as the argo-helm subproject.  
 
 ## Roles and Membership
 Roles are described in the [Community Membership](https://github.com/argoproj/argoproj/blob/master/community/membership.md) document

--- a/community/GOVERNANCE.md
+++ b/community/GOVERNANCE.md
@@ -1,5 +1,5 @@
 # Argo Governance
-This document outlines the governance for the overall Argo Project and the four core sub-projects contained within, as well as the argo-helm subproject.  
+This document outlines the governance for the overall Argo Project and the four core sub-projects contained within, as well as the argo-helm sub-project.  
 
 ## Roles and Membership
 Roles are described in the [Community Membership](https://github.com/argoproj/argoproj/blob/master/community/membership.md) document

--- a/community/README.md
+++ b/community/README.md
@@ -27,6 +27,10 @@ The projects are:
 * [Argo Workflows](https://github.com/argoproj/argo-workflows) - Container-native Workflow Engine
 * [Argo Rollouts](https://github.com/argoproj/argo-rollouts) - Progressive Delivery with support for Canary and Blue Green deployment strategies
 
+For the purpose of governance, there is one additional project:
+
+* [Argo Helm](https://github.com/argoproj/argo-helm) - Helm chart for Argo
+
 ## Community Meetings
 
 Approvers and leads for each project are responsible for organizing regular community meetings to provide status updates and solicit feedback.

--- a/community/ecosystem-projects.md
+++ b/community/ecosystem-projects.md
@@ -3,7 +3,7 @@
 ## About
 
 
-The [Argo Project](https://github.com/argoproj) consists of four core projects that implement the main use-cases. 
+The [Argo Project](https://github.com/argoproj) consists of four core sub-projects that implement the main use-cases. 
 For the purposes of governance, [Argo Helm](https://github.com/argoproj/argo-helm) acts as a "fifth project."
 In addition to the core project repositories the [Argo Project Labs](https://github.com/argoproj-labs) organization hosts repositories of dependencies and ecosystem projects associated with the core projects.
 

--- a/community/ecosystem-projects.md
+++ b/community/ecosystem-projects.md
@@ -3,11 +3,13 @@
 ## About
 
 
-The [Argo Project](https://github.com/argoproj) consists of four core projects that implement the main use-cases. In addition to the core project repositories the [Argo Project Labs](https://github.com/argoproj-labs) organization hosts repositories of dependencies and ecosystem projects associated with the core projects.
+The [Argo Project](https://github.com/argoproj) consists of four core projects that implement the main use-cases. 
+For the purposes of governance, [Argo Helm](https://github.com/argoproj/argo-helm) acts as a "fifth project."
+In addition to the core project repositories the [Argo Project Labs](https://github.com/argoproj-labs) organization hosts repositories of dependencies and ecosystem projects associated with the core projects.
 
 * Core project dependencies are projects which are either shared code libraries (such as [gitops-engine](https://github.com/argoproj/gitops-engine),
 [pkg](https://github.com/argoproj/pkg) or [argo-ui](https://github.com/argoproj/argo-ui) ) or repositories that host release/deployments
-artifacts ( such as [argo-helm](https://github.com/argoproj/argo-helm), or [homebrew-tap](https://github.com/argoproj/homebrew-tap) ). 
+artifacts or [homebrew-tap](https://github.com/argoproj/homebrew-tap)). 
 
 * The ecosystem projects are those projects which implement experimental features or opinionated use cases that are useful for the sub-set of users.
 

--- a/community/membership.md
+++ b/community/membership.md
@@ -1,12 +1,14 @@
 # Community Membership
 
 This document outlines the various responsibilities of contributor roles in
-Argoproj. The Argo project is currently subdivided into four main subprojects:
+Argoproj. The Argo project is currently subdivided into four core sub-projects:
 
 * [Argo Workflows](https://github.com/argoproj/argo-workflows)
 * [Argo CD](https://github.com/argoproj/argo-cd)
 * [Argo Events](https://github.com/argoproj/argo-events)
 * [Argo Rollouts](https://github.com/argoproj/argo-rollouts)
+
+For the purposes of governance, [Argo Helm](https://github.com/argoproj/argo-helm) serves as a fifth sub-project.
 
 Responsibilities for roles are scoped to these subprojects.
 
@@ -58,7 +60,7 @@ Defined by: Member of the Argoproj GitHub organization
 - Sponsored by 2 approvers or leads. **Note the following requirements for sponsors**:
     - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating
       on issues, etc.
-    - Sponsors must be approvers in at least 1 OWNERS file either in any of the four main subprojects in the [Argoproj org].
+    - Sponsors must be approvers in at least 1 OWNERS file either in any of the four core sub-projects in the [Argoproj org].
       - An approver in the [Argoproj org] may sponsor someone for the [Argoproj org]
       or any of the related [Argoproj GitHub organizations]; as long as it's a project they're involved with.
       - A sponsor who is an approver in any of the related [Argoproj GitHub organizations]


### PR DESCRIPTION
Closes https://github.com/argoproj/argoproj/issues/239
Closes #230 
Closes #210

Argo Helm has become an active an effective part of the Argo project community. It effectively has its own governance structure.

This PR would bootstrap Argo Helm into the broader Argoproj ecosystem by

1) Adding its two effective leads
2) Mentioning it as an Argo project "for the purposes of governance"

I believe this is a lightweight and un-intrusive way to recognize the essential role Argo Helm plays in the Argo ecosystem.

**Potential alternatives:**

* Build CI processes to pull Helm manifests out of upstream repos
   * Pros: no change to governance
   * Cons: lots of CI work