### PR TITLE
docs: approver role should clarify that PR contributions and PR reviews are both expected for Approver role

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -169,9 +169,12 @@ in an `OWNERS` file.
 - Reviewer for or author of at least 10 substantial PRs to the codebase, with the
   definition of substantial subject to the lead's discretion (e.g.
   refactors, enhancements rather than grammar correction or one-line pulls).
+- Exhibiting sound technical judgment through PR contributions
+- Exhibiting sound technical judgment through PR reviews
 - Sponsored by a subproject lead
   - With no objections from other leads
   - Done through PR to update the OWNERS file
+
 
 ### Responsibilities and privileges
 


### PR DESCRIPTION
I think we'd like for future Approvers to show us both their own PRs as well as show us their reviews, the latter because they will be able to merge PRs and need to be trusted to do so, and the former because it's probably necessary to spend time with code making modifications to it in order to be good at doing reviews for that code.