### PR TITLE
Add Caelan Urquhart to sig-marketing

### DIFF
--- a/sigs/sig-marketing/README.md
+++ b/sigs/sig-marketing/README.md
@@ -27,3 +27,4 @@ Sig marketing meetings are held twice monthly. Meetings can be found in the [Arg
 | Wojtek Cichoń | Akuity | wojtek@akuity.io  |
 | Christian Hernandez | Red Hat | christian@redhat.com  |
 | Hong Wang | Akuity | hong@akuity.io  |
+| Caelan Urquhart | Pipekit | caelan_u@pipekit.io |


### PR DESCRIPTION
Caelan has been a huge booster and link in the Argo Workflows community and has helped review talks and organize two ArgoCon's. I think his help has been invaluable and I propose he be added to sig-marketing. 