### PR TITLE
Add Meghan Murphy to sig-marketing

### DIFF
--- a/sigs/sig-marketing/README.md
+++ b/sigs/sig-marketing/README.md
@@ -27,3 +27,4 @@ Sig marketing meetings are held twice monthly. Meetings can be found in the [Arg
 | Wojtek Cichoń | Akuity | wojtek@akuity.io  |
 | Christian Hernandez | Red Hat | christian@redhat.com  |
 | Hong Wang | Akuity | hong@akuity.io  |
+| Meghan Murphy | Intuit | Meghan_Murphy@intuit.com |


### PR DESCRIPTION
Meghan served as ArgoCon co-chair in Chicago and is a regular contributor to sig-marketing. 