### PR TITLE
Add Harriet Lawrence to sig-marketing

### DIFF
--- a/sigs/sig-marketing/README.md
+++ b/sigs/sig-marketing/README.md
@@ -27,3 +27,4 @@ Sig marketing meetings are held twice monthly. Meetings can be found in the [Arg
 | Wojtek Cichoń | Akuity | wojtek@akuity.io  |
 | Christian Hernandez | Red Hat | christian@redhat.com  |
 | Hong Wang | Akuity | hong@akuity.io  |
+| Harriet Lawrence | Red Hat | halawren@redhat.com |


### PR DESCRIPTION
Harriet has been an active contributor to sig-marketing, helped organize and manage talks at ArgoCon, and provided valuable insights to the sig. 