### PR TITLE
Set Dan Garfield as sig-marketing lead

### DIFF
--- a/sigs/sig-marketing/README.md
+++ b/sigs/sig-marketing/README.md
@@ -17,13 +17,17 @@ Sig marketing meetings are held twice monthly. Meetings can be found in the [Arg
 |-------------------|------------------------------------------------------|
 | Member | Create and approve official communications (emails, social, blogs, etc). Manage and work on official events. Work in comittee on projects as deemed appropriate by ArgoProj maintainers. Provide regular updates to maintainers on marketing initiatives. |
 | Interested Party | Provide support, create content, and assist with sig-marketing intiatives. No nomination required to be added as an intersted party. |
-| Secretary/Coordinator | Coordinates work in the SIG. Leads and runs the SIG Marketing meetings. Reports back on SIG Marketing completed and upcoming work to maintainers. |
+| Lead | Coordinates work in the SIG. Leads and runs the SIG Marketing meetings. Reports back on SIG Marketing completed and upcoming work to maintainers. |
+
+## Sig-Lead
+| Name | Company | Email |
+|--------------------------|-------------|---------------------|
+| Dan Garfield | Codefresh | dan@codefresh.io |
 
 ## Members
 | Name | Company | Email |
 |--------------------------|-------------|---------------------|
 | Henrik Blixt | Intuit | Henrik_Blixt@intuit.com  |
-| Dan Garfield | Codefresh | dan@codefresh.io
 | Wojtek Cichoń | Akuity | wojtek@akuity.io  |
 | Christian Hernandez | Akuity | christian@akuity.io  |
 | Hong Wang | Akuity | hong@akuity.io  |


### PR DESCRIPTION
Voted on and approved by Argo Maintainers in Dec 5th 2023 meeting. 