### PR TITLE
Nominate Michael and Jann as sig-leads for sig-security

### DIFF
--- a/sigs/sig-security/README.md
+++ b/sigs/sig-security/README.md
@@ -12,6 +12,7 @@ Argo Project security policy and instructions for reporting issues are available
 | Name                                                    | Company   | Email                       |
 |---------------------------------------------------------|-----------|-----------------------------|
 | [Michael Crenshaw](https://github.com/crenshaw-dev)     | Intuit    |                             |
+| [Jann Fischer](https://github.com/jannfis)              | RedHat    |                             |
 
 ## Members
 | Name                                                    | Company   | Email                       |

--- a/sigs/sig-security/README.md
+++ b/sigs/sig-security/README.md
@@ -8,6 +8,11 @@ Sig security meetings include public and non-public sections and are held twice 
 ## Security Policy and Reporting Issues
 Argo Project security policy and instructions for reporting issues are available [here](https://github.com/argoproj/argoproj/blob/master/SECURITY.md).
 
+## Sig-Lead
+| Name                                                    | Company   | Email                       |
+|---------------------------------------------------------|-----------|-----------------------------|
+| [Michael Crenshaw](https://github.com/crenshaw-dev)     | Intuit    |                             |
+
 ## Members
 | Name                                                    | Company   | Email                       |
 |---------------------------------------------------------|-----------|-----------------------------|


### PR DESCRIPTION
Michael has been defacto sig-lead for a while. He's organized better reporting systems, takes the lead on the administration of the project, and he has several times made proactive changes to improve project security and orientation. He is the natural choice for the job.