### PR TITLE
Argoproj promotions/membership

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,52 +6,58 @@
 
 ## Maintainers
 
-| Maintainer                | GitHub ID                                               | Project Roles                                          | Affiliation                                    |
-|---------------------------|---------------------------------------------------------|--------------------------------------------------------|------------------------------------------------|
-| Rohit Agrawal             | [agrawroh](https://github.com/agrawroh)                 | Reviewer - Rollouts                                    | [Databricks](https://databricks.com/)          |
-| Zach Aller                | [zachaller](https://github.com/zachaller)               | Lead - Rollouts <br/>Reviewer - CD                     | [Intuit](https://www.github.com/intuit/)       |
-| Leonardo Luz Almeida      | [leoluz](https://github.com/leoluz)                     | Approver - CD, Rollouts                                | [Intuit](https://www.github.com/intuit/)       |
-| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Lead - Workflows                                       | [Intuit](https://www.github.com/intuit/)       |
-| Chetan Banavikalmutt      | [chetan-rns](https://github.com/chetan-rns)             | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Henrik Blixt              | [hblixt](https://github.com/hblixt)                     | Reviewer                                               | [Intuit](https://www.github.com/intuit/)       |
-| Shoubhik Bose             | [sbose78](https://github.com/sbose78)                   | Reviewer                                               | [Red Hat](https://www.github.com/redhat/)      |
-| Remington Breeze          | [rbreeze](https://github.com/rbreeze)                   | Approver CD, Rollouts                                  | [Akuity](https://akuity.io/)                   |
-| Yi Cai                    | [ciiay](https://github.com/ciiay)                       | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Reviewer - Workflows                                   | [Pipekit](https://www.pipekit.io/)             |
-| Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD                | [Intuit](https://www.github.com/intuit/)       |
-| Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)       |
-| Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Approver - CD                                          | [Akuity](https://akuity.io/)                   |
-| Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                          | [GetYourGuide](https://www.getyourguide.com/)  |
-| Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                    | [Codefresh](https://www.github.com/codefresh/) |
-| Anton Gilgur              | [agilgur5](https://github.com/agilgur5)                 | Reviewer - Workflows                                   | Independent                                    |
-| Ravi Hari                 | [RaviHari](https://github.com/RaviHari)                 | Reviewer - Rollouts                                    | [Intuit](https://www.github.com/intuit/)       |
-| Saumeya Katyal            | [saumeya](https://github.com/saumeya)                   | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                    | [Codefresh](https://www.github.com/codefresh/) |
-| Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                          | [Codefresh](https://www.github.com/codefresh/) |
-| Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                           | [Intuit](https://www.github.com/intuit/)       |
-| Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                 | [Akuity](https://akuity.io/)                   |
-| Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows          | [Akuity](https://akuity.io/)                   |
-| Marco Maurer              | [mkilchhofer](https://github.com/mkilchhofer)           | Approver(helm-chart) - CD, Events, Rollouts, Workflows | [Swiss Post](https://post.ch/)                 |
-| Jason Meridth             | [jmeridth](https://github.com/jmeridth)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows | [Procore](https://www.procore.com/)            |
-| Nicholas Morey            | [morey-tech](https://github.com/morey-tech)             | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                   |
-| Blake Pettersson          | [blakepettersson](https://github.com/blakepettersson)   | Approver(docs) - CD                                    | [Akuity](https://akuity.io/)                   |
-| Hari Rongali              | [harikrongali](https://github.com/harikrongali)         | Reviewer - Rollouts                                    | [Lacework](https://github.com/lacework)        |
-| Regina Scott              | [reginapizza](https://github.com/reginapizza)           | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Ishita Sequeira           | [ishitasequeira](https://github.com/ishitasequeira)     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Ashutosh Singh            | [ashutosh16](https://github.com/ashutosh16)             | Reviewer - CD                                          | [Intuit](https://www.github.com/intuit/)       |
-| Daniel Soifer             | [daniel-codefresh](https://github.com/daniel-codefresh) | Reviewer - Events                                      | [Codefresh](https://www.github.com/codefresh/) |
-| Isitha Subasinghe         | [isubasinghe](https://github.com/isubasinghe)           | Reviewer - Workflows                                   | [Pipekit](https://pipekit.io/)                 |
-| Jesse Suen                | [jessesuen](https://github.com/jessesuen)               | Lead - CD, Rollouts <br/>Approver - Workflows, Events  | [Akuity](https://akuity.io/)                   |
-| Yuan Tang                 | [terrytangyuan](https://github.com/terrytangyuan)       | Lead - Workflows <br/>Reviewer - CD                    | [Red Hat](https://www.github.com/redhat/)      |
-| William Tam               | [wtam2018](https://github.com/wtam2018)                 | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| Julie Vogelman            | [juliev0](https://github.com/juliev0)                   | Approver - Workflows                                   | [Intuit](https://www.github.com/intuit/)       |
-| Derek Wang                | [whynowy](https://github.com/whynowy)                   | Lead - Events                                          | [Intuit](https://www.github.com/intuit/)       |
-| Hong Wang                 | [wanghong230](https://github.com/wanghong230)           | Reviewer                                               | [Akuity](https://akuity.io/)                   |
-| Jonathan West             | [jgwest](https://github.com/jgwest)                     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)      |
-| May Zhang                 | [mayzhang2000](https://github.com/mayzhang2000)         | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)       |
-| Tianchu Zhao              | [tczhao](https://github.com/tczhao)                     | Reviewer - Workflows                                   | Independent                                    |
+| Maintainer                | GitHub ID                                               | Project Roles                                          | Affiliation                                          |
+|---------------------------|---------------------------------------------------------|--------------------------------------------------------|------------------------------------------------------|
+| Rohit Agrawal             | [agrawroh](https://github.com/agrawroh)                 | Reviewer - Rollouts                                    | [Databricks](https://databricks.com/)                |
+| Aikawa                    | [yu-croco](https://github.com/yu-croco)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows |                                                      |
+| Zach Aller                | [zachaller](https://github.com/zachaller)               | Lead - Rollouts <br/>Reviewer - CD                     | [Intuit](https://www.github.com/intuit/)             |
+| Leonardo Luz Almeida      | [leoluz](https://github.com/leoluz)                     | Approver - CD, Rollouts                                | [Intuit](https://www.github.com/intuit/)             |
+| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Lead - Workflows                                       | [Intuit](https://www.github.com/intuit/)             |
+| Chetan Banavikalmutt      | [chetan-rns](https://github.com/chetan-rns)             | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Marko Bevc                | [mbevc1](https://github.com/mbevc1)                     | Approver(helm-chart) - CD                              | [The Scale Factory](https://github.com/scalefactory) |
+| Henrik Blixt              | [hblixt](https://github.com/hblixt)                     | Reviewer                                               | [Intuit](https://www.github.com/intuit/)             |
+| Shoubhik Bose             | [sbose78](https://github.com/sbose78)                   | Reviewer                                               | [Red Hat](https://www.github.com/redhat/)            |
+| Remington Breeze          | [rbreeze](https://github.com/rbreeze)                   | Approver CD, Rollouts                                  | [Akuity](https://akuity.io/)                         |
+| Yi Cai                    | [ciiay](https://github.com/ciiay)                       | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Reviewer - Workflows                                   | [Pipekit](https://www.pipekit.io/)                   |
+| Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD                | [Intuit](https://www.github.com/intuit/)             |
+| Tim Collins               | [tico24](https://github.com/tico24)                     | Approver(helm-chart) - CD, Events, Workflows           | [Pipekit](https://pipekit.io/)                       |
+| Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)             |
+| Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Approver - CD                                          | [Akuity](https://akuity.io/)                         |
+| Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Approver(helm-chart) - CD, Events                      | Independent                                          |
+| Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                          | [GetYourGuide](https://www.getyourguide.com/)        |
+| Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                    | [Codefresh](https://www.github.com/codefresh/)       |
+| Anton Gilgur              | [agilgur5](https://github.com/agilgur5)                 | Approver - Workflows                                   | Independent                                          |
+| Ravi Hari                 | [RaviHari](https://github.com/RaviHari)                 | Reviewer - Rollouts                                    | [Intuit](https://www.github.com/intuit/)             |
+| Christian Hernandez       | [christianh814](https://github.com/christianh814)       | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
+| Saumeya Katyal            | [saumeya](https://github.com/saumeya)                   | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                    | [Codefresh](https://www.github.com/codefresh/)       |
+| Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                          | [Codefresh](https://www.github.com/codefresh/)       |
+| Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                           | [Intuit](https://www.github.com/intuit/)             |
+| Vlad Losev                | [vladlosev](https://github.com/vladlosev)               | Approver(helm-chart) - CD                              | [Sage Intacct](https://github.com/intacct)           |
+| Justin Marquis            | [34fathombelow](https://github.com/34fathombelow)       | Approver(docs/ci) - CD                                 | [Akuity](https://akuity.io/)                         |
+| Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD, Rollouts <br/>Approver - Workflows          | [Akuity](https://akuity.io/)                         |
+| Marco Maurer              | [mkilchhofer](https://github.com/mkilchhofer)           | Approver(helm-chart) - CD, Events, Rollouts, Workflows | [Swiss Post](https://post.ch/)                       |
+| Jason Meridth             | [jmeridth](https://github.com/jmeridth)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows | [Procore](https://www.procore.com/)                  |
+| Nicholas Morey            | [morey-tech](https://github.com/morey-tech)             | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
+| Blake Pettersson          | [blakepettersson](https://github.com/blakepettersson)   | Approver(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
+| Hari Rongali              | [harikrongali](https://github.com/harikrongali)         | Reviewer - Rollouts                                    | [Lacework](https://github.com/lacework)              |
+| Regina Scott              | [reginapizza](https://github.com/reginapizza)           | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Ishita Sequeira           | [ishitasequeira](https://github.com/ishitasequeira)     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Ashutosh Singh            | [ashutosh16](https://github.com/ashutosh16)             | Approver(docs) - CD                                    | [Intuit](https://www.github.com/intuit/)             |
+| Daniel Soifer             | [daniel-codefresh](https://github.com/daniel-codefresh) | Reviewer - Events                                      | [Codefresh](https://www.github.com/codefresh/)       |
+| Isitha Subasinghe         | [isubasinghe](https://github.com/isubasinghe)           | Approver - Workflows                                   | [Pipekit](https://pipekit.io/)                       |
+| Jesse Suen                | [jessesuen](https://github.com/jessesuen)               | Lead - CD, Rollouts <br/>Approver - Workflows, Events  | [Akuity](https://akuity.io/)                         |
+| Yuan Tang                 | [terrytangyuan](https://github.com/terrytangyuan)       | Lead - Workflows <br/>Reviewer - CD                    | [Red Hat](https://www.github.com/redhat/)            |
+| William Tam               | [wtam2018](https://github.com/wtam2018)                 | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| Julie Vogelman            | [juliev0](https://github.com/juliev0)                   | Approver - Workflows                                   | [Intuit](https://www.github.com/intuit/)             |
+| Derek Wang                | [whynowy](https://github.com/whynowy)                   | Lead - Events                                          | [Intuit](https://www.github.com/intuit/)             |
+| Hong Wang                 | [wanghong230](https://github.com/wanghong230)           | Reviewer                                               | [Akuity](https://akuity.io/)                         |
+| Jonathan West             | [jgwest](https://github.com/jgwest)                     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
+| May Zhang                 | [mayzhang2000](https://github.com/mayzhang2000)         | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)             |
+| Tianchu Zhao              | [tczhao](https://github.com/tczhao)                     | Reviewer - Workflows                                   | Independent                                          |
 
 ## Alumni
 


### PR DESCRIPTION
# Argoproj promotions/membership

Every quarter, the Argoproj maintainers review requests for project membership and promotions (read about the roles [here](https://github.com/argoproj/argoproj/blob/master/community/membership.md#community-membership)). The changes below recognize the incredible efforts and commitment to the project by these people. Thank you so much!

## 🚀  Maintainer promotions

Congrats to the following contributors for their promotions:

* Anton Gilgur (@agilgur5) to Approver in Argo Workflows
* Christian Hernandez (@christianh814) to Reviewer(docs) in Argo CD
* Ashutosh Singh (@ashutosh16) to Approver(docs) in Argo CD
* Isitha Subasinghe (@isubasinghe) to Approver in Argo Workflows

## 🐙 Helm chart maintainers

The [Argo Helm chart](https://github.com/argoproj/argo-helm)'s existing maintainers are now fully represented in the Argoproj maintainers list! Thanks to you all for your amazing work.

* Aikawa (@yu-croco), Approver(helm-chart) for all Argo subprojects
* Marko Bevc (@mbevc1), Approver(helm-chart) for Argo CD
* Tim Collins (@tico24), Approver(helm-chart) for Argo CD, Events, and Workflows
* Petr Drastil (@pdrastil), Approver(helm-chart) for Argo CD and Events
* Vlad Losev (@vladlosev), Approver(helm-chart) for Argo CD

## ⭐  New members

An additional congratulations to the following folks for becoming Argoproj members:

* Robin Lieb (@robinlieb)
* Garett MacGowan (@Garett-MacGowan
* Alexy Mantha (@alexymantha)
* Eduardo Rogdriguez (@eduardobr)
* Carlos Santana (@csantanapr)
* Sonam Shenoy (@sonamkshenoy)
* Shuangkun Tian (@shuangkun)

You all will receive invitations on GitHub to become members of the Argoproj organization.

Closes #232 
Closes #234 
Closes #253 
Closes #254 
Closes #255 
Closes #256 
Closes #266 
Closes #267 
Closes #269 
Closes #271 
Closes #272 
Closes #273 
Closes #274 
Closes #275 
Closes #277 
Closes #279