### PR TITLE
chore(docs): add z3r0sum (stephen schmidt) to SIG Scalability

### DIFF
--- a/sigs/sig-scalability/README.md
+++ b/sigs/sig-scalability/README.md
@@ -30,5 +30,6 @@ To join, create a pull request adding yourself to the list below.
 | [Michael Crenshaw](https://github.com/crenshaw-dev)    | Intuit    |       |
 | [Nicholas Morey](https://github.com/morey-tech)        | Akuity    |       |
 | [Nima Kaviani](https://github.com/nimakaviani)         | AWS       |       |
+| [Stephen Schmidt](https://github.com/z3r0sum)          | Elastic   |       |
 | [Vikram Sethi](https://github.com/vsethi)              | Adobe     |       |
 | [Zach Aller](https://github.com/zachaller)             | Intuit    |       |


### PR DESCRIPTION
 ## Summary
 
  - At Elastic, we're increasingly interested in getting involved in helping the community with aspects of scaling Argo CD; thus, I'd very much like to be involved in this SIG