### PR TITLE
Add Chris Van Dal to sig-security

### DIFF
--- a/sigs/sig-security/README.md
+++ b/sigs/sig-security/README.md
@@ -13,6 +13,7 @@ Argo Project security policy and instructions for reporting issues are available
 |---------------------------------------------------------|-----------|-----------------------------|
 | [Abhishek Veeramalla](https://github.com/iam-veermalla) | Red Hat   |                             |
 | [Alexander Matyushentsev](https://github.com/alexmt)    | Akuity    |                             |
+| [Chris van Dal](https://github.com/cvandal)                                           | Codefresh |  |
 | [Dan Garfield](https://github.com/todaywasawesome)      | Codefresh | dan@codefresh.io            |
 | [Ed Lee](https://github.com/edlee2121)                  | Intuit    |                             |
 | [Henrik Blixt](https://github.com/hblixt)               | Intuit    | Henrik_Blixt@intuit.com     |
@@ -21,6 +22,5 @@ Argo Project security policy and instructions for reporting issues are available
 | [Leonardo Luz](https://github.com/leoluz)               | Intuit    |                             |
 | [Michael Crenshaw](https://github.com/crenshaw-dev)     | Intuit    |                             | 
 | [Pavel Kostohrys](https://github.com/pasha-codefresh)   | Codefresh |                             |
-| Sasha Shapiro                                           | Codefresh | sasha.shapirov@codefresh.io |
 | [William Tam](https://github.com/wtam2018)              | Red Hat   |                             |
 | [Zach Aller](https://github.com/zachaller)              | Intuit    |                             |


### PR DESCRIPTION
Hey all, 

I want to first thank Sasha for all of his help and work on sig-security over the last few years. He's moved onto a new role and won't be participating any longer. 

In this PR we'd like to add Chris Van Dal to the sig. Chris has 20 years of experience and leads security and incident response at Octopus Deploy. I think he would be an invaluable addition to help triage issues, contribute code/fixes etc, as well as improving incident response overall. 