### PR TITLE
fix(gh): use correct labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -2,7 +2,7 @@
 name: Organization Membership Request
 about: Request membership in a Argoproj Org
 title: 'REQUEST: New membership for <your-GH-handle>'
-labels: area/github-membership
+labels: type/membership-request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/promotion-approver.md
+++ b/.github/ISSUE_TEMPLATE/promotion-approver.md
@@ -2,7 +2,7 @@
 name: Organization Approver Promotion Request
 about: Request promotion in a Argoproj Org
 title: 'REQUEST: Promotion to Approver for <your-GH-handle>'
-labels: area/github-membership
+labels: type/promotion-request
 assignees: ''
 
 ---
@@ -17,7 +17,7 @@ IMPORTANT: A request for promotion to Approver should be initiated by an Approve
 
 ### Sub-project(s)
 
-Promotion is requested for the following sub-project(s). 
+Promotion is requested for the following sub-project(s).
 
 - [ ] Argo CD
 - [ ] Argo Events

--- a/.github/ISSUE_TEMPLATE/promotion-reviewer.md
+++ b/.github/ISSUE_TEMPLATE/promotion-reviewer.md
@@ -2,7 +2,7 @@
 name: Organization Reviewer Promotion Request
 about: Request promotion in a Argoproj Org
 title: 'REQUEST: Promotion to Reviewer for <your-GH-handle>'
-labels: area/github-membership
+labels: type/promotion-request
 assignees: ''
 
 ---


### PR DESCRIPTION
### Motivation

- `area/github-membership` [doesn't exist](https://github.com/argoproj/argoproj/labels) -- I'm not sure if it did at some point though
- I added [`type/membership-request`](https://github.com/argoproj/argoproj/labels/type%2Fmembership-request) and [`type/promotion-request`](https://github.com/argoproj/argoproj/labels/type%2Fpromotion-request) recently once I had Approver/write permissions, so let's use those
  - I also labeled lots of previous requests with those
  - [`type/*`](https://github.com/argoproj/argo-workflows/labels?q=type%2F) matches the categorization of issue ["types"](https://github.com/argoproj/argo-workflows/blob/ed55b02992d5774e6d7ccb56bef73c27cb0c5fd2/.github/ISSUE_TEMPLATE/bug_report.yaml?plain=1#L3) we have in Workflows
    - whereas `area/*` is for the _scope_ of the issue/PR with respect to the codebase (same terminology as conventional commits)
  
### Modifications

- use correct labels in all 3 issue templates in this repo