### PR TITLE
Promote Michael Crenshaw as Argo CD Lead

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,7 +23,7 @@
 | Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Reviewer - Workflows                                   | [Pipekit](https://www.pipekit.io/)                   |
 | Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD                | [Intuit](https://www.github.com/intuit/)             |
 | Tim Collins               | [tico24](https://github.com/tico24)                     | Approver(helm-chart) - CD, Events, Workflows           | [Pipekit](https://pipekit.io/)                       |
-| Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)             |
+| Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Lead - CD                                              | [Intuit](https://www.github.com/intuit/)             |
 | Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Approver - CD                                          | [Akuity](https://akuity.io/)                         |
 | Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Approver(helm-chart) - CD, Events                      | Independent                                          |
 | Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                          | [GetYourGuide](https://www.getyourguide.com/)        |

--- a/OWNERS
+++ b/OWNERS
@@ -5,11 +5,11 @@ owners:
 - terrytangyuan
 - whynowy
 - zachaller
+- crenshaw-dev
 
 approvers:
 - agilgur5
 - alexec
-- crenshaw-dev
 - gdsoumya
 - ishitasequeira
 - isubasinghe


### PR DESCRIPTION
It is with great pleasure I am putting forward @crenshaw-dev as Argo CD Lead. Michael has been invaluable to the Argo project and has effectively been leading Argo CD for the past few years, but just without the title.

In addition to Michael's [storied code contributions](https://github.com/argoproj/argo-cd/commits?author=crenshaw-dev) to Argo CD, he has been an effective and patient steward of the project, while also leading Argo security sig as well.

I think others will agree that this has been long overdue.