### PR TITLE
Argoproj promotions/membership

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,7 +29,7 @@
 | Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                          | [GetYourGuide](https://www.getyourguide.com/)        |
 | Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
 | Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                    | [Codefresh](https://www.github.com/codefresh/)       |
-| Alexandre Gaudreault      | [agaudreault](https://github.com/agaudreault)           | Reviewer - CD                                          | [Intuit](https://www.github.com/intuit/)             |
+| Alexandre Gaudreault      | [agaudreault](https://github.com/agaudreault)           | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)             |
 | Anton Gilgur              | [agilgur5](https://github.com/agilgur5)                 | Approver - Workflows                                   | Independent                                          |
 | Christian Hernandez       | [christianh814](https://github.com/christianh814)       | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
 | Saumeya Katyal            | [saumeya](https://github.com/saumeya)                   | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ owners:
 - crenshaw-dev
 
 approvers:
+- agaudreault
 - agilgur5
 - alexec
 - gdsoumya
@@ -26,7 +27,6 @@ approvers:
 
 reviewers:
 - 34fathombelow
-- agaudreault
 - agrawroh
 - alexef
 - ashutosh16


### PR DESCRIPTION
# Argoproj promotions/membership

Every quarter, the Argoproj maintainers review requests for project membership and promotions (read about the roles [here](https://github.com/argoproj/argoproj/blob/master/community/membership.md#community-membership)). The changes below recognize the incredible efforts and commitment to the project by these people. Thank you so much!

## 🚀  Maintainer promotions

Congrats to the following contributor for their promotion:

* Alexandre Gaudreault (@agaudreault ) to Approver in Argo CD

## ⭐  New members

An additional congratulations to the following folks for becoming Argoproj members:

- Miltiadis Alexis (@miltalex)
- Adrien Delannoy (@Adrien-D)
- Andrew Lee (@Enclavet)
- Kevin (@juwon8891)
- Ryan Umstead (@rumstead)

You all will receive invitations on GitHub to become members of the Argoproj organization.

Closes #314
Closes #313
Closes #312
Closes #310
Closes #307
Closes #302