### PR TITLE
Update the affiliation of dtaniwaki in the MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -72,4 +72,4 @@
 | Mikhail Mazurskiy  | [ash2k](https://github.com/ash2k)             | Reviewer - CD                | [GitLab](https://www.github.com/gitlab/)        |
 | Vaibhav Page       | [VaibhavPage](https://github.com/VaibhavPage) | Lead - Events                | [Black Rock](https://www.github.com/blackrock/) |
 | Andrii Perenesenko | [perenesenko](https://github.com/perenesenko) | Reviewer - Rollouts          | [Capital One](https://github.com/capitalone/)   |
-| Daisuke Taniwaki   | [dtaniwaki](https://github.com/dtaniwaki)     | Approver - Workflows, Events | [Ubie](https://ubie.life/)                      |
+| Daisuke Taniwaki   | [dtaniwaki](https://github.com/dtaniwaki)     | Approver - Workflows, Events | [JMDC](https://www.jmdc.co.jp/en/)                      |


### PR DESCRIPTION
Long time no see! Thank you for having me in the Alumni list. I don’t have chances to contribute to the community now as my current company doesn’t use Kubernetes at all. By the way, my belonging company is not up-to-date in the list, so could you update it?