### PR TITLE
Argoproj promotions/membership

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@
 | Remington Breeze          | [rbreeze](https://github.com/rbreeze)                   | Approver CD, Rollouts                                  | [Akuity](https://akuity.io/)                         |
 | Yi Cai                    | [ciiay](https://github.com/ciiay)                       | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
 | Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
-| Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Approver - Workflows                                   | [Pipekit](https://www.pipekit.io/)                   |
+| Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Lead - Workflows                                       | [Pipekit](https://www.pipekit.io/)                   |
 | Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD                | [Intuit](https://www.github.com/intuit/)             |
 | Tim Collins               | [tico24](https://github.com/tico24)                     | Approver(helm-chart) - CD, Events, Workflows           | [Pipekit](https://pipekit.io/)                       |
 | Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Lead - CD                                              | [Intuit](https://www.github.com/intuit/)             |
@@ -31,6 +31,7 @@
 | Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                    | [Codefresh](https://www.github.com/codefresh/)       |
 | Alexandre Gaudreault      | [agaudreault](https://github.com/agaudreault)           | Approver - CD                                          | [Intuit](https://www.github.com/intuit/)             |
 | Christian Hernandez       | [christianh814](https://github.com/christianh814)       | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
+| jswxstw                   | [jswxstw](https://github.com/jswxstw)                   | Reviewer - Workflows                                   | Independent                                          |
 | Saumeya Katyal            | [saumeya](https://github.com/saumeya)                   | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
 | Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                    | [Codefresh](https://www.github.com/codefresh/)       |
 | Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                          | [Codefresh](https://www.github.com/codefresh/)       |
@@ -42,17 +43,17 @@
 | JM (Jason Meridth)        | [jmeridth](https://github.com/jmeridth)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows | [GitHub](https://github.com/)                        |
 | Nicholas Morey            | [morey-tech](https://github.com/morey-tech)             | Reviewer(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
 | Blake Pettersson          | [blakepettersson](https://github.com/blakepettersson)   | Approver(docs) - CD                                    | [Akuity](https://akuity.io/)                         |
-| Hari Rongali              | [harikrongali](https://github.com/harikrongali)         | Reviewer - Rollouts                                    | [Lacework](https://github.com/lacework)              |
 | Regina Scott              | [reginapizza](https://github.com/reginapizza)           | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
 | Ishita Sequeira           | [ishitasequeira](https://github.com/ishitasequeira)     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
 | Ashutosh Singh            | [ashutosh16](https://github.com/ashutosh16)             | Approver(docs) - CD                                    | [Intuit](https://www.github.com/intuit/)             |
-| Daniel Soifer             | [daniel-codefresh](https://github.com/daniel-codefresh) | Reviewer - Events                                      | [Codefresh](https://www.github.com/codefresh/)       |
 | Isitha Subasinghe         | [isubasinghe](https://github.com/isubasinghe)           | Approver - Workflows                                   | [Pipekit](https://pipekit.io/)                       |
 | Jesse Suen                | [jessesuen](https://github.com/jessesuen)               | Lead - CD, Rollouts <br/>Approver - Workflows, Events  | [Akuity](https://akuity.io/)                         |
 | Yuan Tang                 | [terrytangyuan](https://github.com/terrytangyuan)       | Lead - Workflows <br/>Reviewer - CD                    | [Red Hat](https://www.github.com/redhat/)            |
 | William Tam               | [wtam2018](https://github.com/wtam2018)                 | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
-| Shuangkun Tian            | [shuangkun](https://github.com/shuangkun)               | Reviewer - Workflows                                   | Alibaba                                              |
+| Shuangkun Tian            | [shuangkun](https://github.com/shuangkun)               | Approver - Workflows                                   | Alibaba                                              |
+| Ryan Umstead              | [rumstead](https://github.com/rumstead)                 | Reviewer - CD                                          | [Black Rock](https://www.github.com/blackrock/)      |
 | Julie Vogelman            | [juliev0](https://github.com/juliev0)                   | Approver - Workflows                                   | [Intuit](https://www.github.com/intuit/)             |
+| Regina Voloshin           | [reggie-k](https://github.com/reggie-k)                 | Reviewer - CD                                          | [Codefresh](https://www.github.com/codefresh/)       |
 | Derek Wang                | [whynowy](https://github.com/whynowy)                   | Lead - Events                                          | [Intuit](https://www.github.com/intuit/)             |
 | Hong Wang                 | [wanghong230](https://github.com/wanghong230)           | Reviewer                                               | [Akuity](https://akuity.io/)                         |
 | Jonathan West             | [jgwest](https://github.com/jgwest)                     | Approver - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
@@ -61,15 +62,17 @@
 
 ## Alumni
 
-| Alumni             | GitHub ID                                     | Project Roles                | Affiliation                                     |
-|--------------------|-----------------------------------------------|------------------------------|-------------------------------------------------|
-| Simon Behar        | [simster7](https://github.com/simster7)       | Approver - Workflows         | [AirBnB](https://www.github.com/airbnb/)        |
-| Xianlu Chen        | [xianlubird](https://github.com/xianlubird)   | Reviewer - Workflows         | [Alibaba Cloud](https://github.com/aliyun)      |
-| Ravi Hari          | [RaviHari](https://github.com/RaviHari)       | Reviewer - Rollouts          | [Intuit](https://www.github.com/intuit/)        |
-| Kareena Hirani     | [khhirani](https://github.com/khhirani)       | Approver - Rollouts          | Independent                                     |
-| Hui Kang           | [huikang](https://github.com/huikang)         | Approver - Rollouts          | [Salesforce](https://salesforce.com/)           |
-| Mikhail Mazurskiy  | [ash2k](https://github.com/ash2k)             | Reviewer - CD                | [GitLab](https://www.github.com/gitlab/)        |
-| Vaibhav Page       | [VaibhavPage](https://github.com/VaibhavPage) | Lead - Events                | [Black Rock](https://www.github.com/blackrock/) |
-| Andrii Perenesenko | [perenesenko](https://github.com/perenesenko) | Reviewer - Rollouts          | [Capital One](https://github.com/capitalone/)   |
-| Daisuke Taniwaki   | [dtaniwaki](https://github.com/dtaniwaki)     | Approver - Workflows, Events | [JMDC](https://www.jmdc.co.jp/en/)              |
-| Anton Gilgur       | [agilgur5](https://github.com/agilgur5)       | Approver - Workflows         | Independent                                     |
+| Alumni             | GitHub ID                                               | Project Roles                | Affiliation                                     |
+|--------------------|---------------------------------------------------------|------------------------------|-------------------------------------------------|
+| Simon Behar        | [simster7](https://github.com/simster7)                 | Approver - Workflows         | [AirBnB](https://www.github.com/airbnb/)        |
+| Xianlu Chen        | [xianlubird](https://github.com/xianlubird)             | Reviewer - Workflows         | [Alibaba Cloud](https://github.com/aliyun)      |
+| Anton Gilgur       | [agilgur5](https://github.com/agilgur5)                 | Approver - Workflows         | Independent                                     |
+| Ravi Hari          | [RaviHari](https://github.com/RaviHari)                 | Reviewer - Rollouts          | [Intuit](https://www.github.com/intuit/)        |
+| Kareena Hirani     | [khhirani](https://github.com/khhirani)                 | Approver - Rollouts          | Independent                                     |
+| Hui Kang           | [huikang](https://github.com/huikang)                   | Approver - Rollouts          | [Salesforce](https://salesforce.com/)           |
+| Mikhail Mazurskiy  | [ash2k](https://github.com/ash2k)                       | Reviewer - CD                | [GitLab](https://www.github.com/gitlab/)        |
+| Vaibhav Page       | [VaibhavPage](https://github.com/VaibhavPage)           | Lead - Events                | [Black Rock](https://www.github.com/blackrock/) |
+| Andrii Perenesenko | [perenesenko](https://github.com/perenesenko)           | Reviewer - Rollouts          | [Capital One](https://github.com/capitalone/)   |
+| Hari Rongali       | [harikrongali](https://github.com/harikrongali)         | Reviewer - Rollouts          | [Lacework](https://github.com/lacework)         |
+| Daisuke Taniwaki   | [dtaniwaki](https://github.com/dtaniwaki)               | Approver - Workflows, Events | [JMDC](https://www.jmdc.co.jp/en/)              |
+| Daniel Soifer      | [daniel-codefresh](https://github.com/daniel-codefresh) | Reviewer - Events            | [Codefresh](https://www.github.com/codefresh/)  |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -50,7 +50,7 @@
 | Jesse Suen                | [jessesuen](https://github.com/jessesuen)               | Lead - CD, Rollouts <br/>Approver - Workflows, Events  | [Akuity](https://akuity.io/)                         |
 | Yuan Tang                 | [terrytangyuan](https://github.com/terrytangyuan)       | Lead - Workflows <br/>Reviewer - CD                    | [Red Hat](https://www.github.com/redhat/)            |
 | William Tam               | [wtam2018](https://github.com/wtam2018)                 | Reviewer - CD                                          | [Red Hat](https://www.github.com/redhat/)            |
-| Shuangkun Tian            | [shuangkun](https://github.com/shuangkun)               | Approver - Workflows                                   | Alibaba                                              |
+| Shuangkun Tian            | [shuangkun](https://github.com/shuangkun)               | Reviewer - Workflows                                   | Alibaba                                              |
 | Ryan Umstead              | [rumstead](https://github.com/rumstead)                 | Reviewer - CD                                          | [Black Rock](https://www.github.com/blackrock/)      |
 | Julie Vogelman            | [juliev0](https://github.com/juliev0)                   | Approver - Workflows                                   | [Intuit](https://www.github.com/intuit/)             |
 | Regina Voloshin           | [reggie-k](https://github.com/reggie-k)                 | Reviewer - CD                                          | [Codefresh](https://www.github.com/codefresh/)       |

--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ owners:
 - whynowy
 - zachaller
 - crenshaw-dev
+- Joibel
 
 approvers:
 - agaudreault
@@ -15,13 +16,13 @@ approvers:
 - isubasinghe
 - jannfis
 - jgwest
-- joibel
 - juliev0
 - keithchong
 - leoluz
 - mayzhang2000
 - pasha-codefresh
 - rbreeze
+- shuangkun
 - tczhao
 
 reviewers:
@@ -35,11 +36,13 @@ reviewers:
 - daniel-codefresh
 - harikrongali
 - hblixt
+- jswxstw
 - kostis-codefresh
 - reginapizza
+- reggie-k
+- rumstead
 - saumeya
 - sbose78
-- shuangkun
 - todaywasawesome
 - wanghong230
 - wtam2018

--- a/OWNERS
+++ b/OWNERS
@@ -22,7 +22,6 @@ approvers:
 - mayzhang2000
 - pasha-codefresh
 - rbreeze
-- shuangkun
 - tczhao
 
 reviewers:
@@ -43,6 +42,7 @@ reviewers:
 - rumstead
 - saumeya
 - sbose78
+- shuangkun
 - todaywasawesome
 - wanghong230
 - wtam2018


### PR DESCRIPTION
# Argoproj promotions/membership

Every quarter, the Argoproj maintainers review requests for project membership and promotions (read about the roles [here](https://github.com/argoproj/argoproj/blob/master/community/membership.md#community-membership)). The changes below recognize the incredible efforts and commitment to the project by these people. Thank you so much!

## 🚀  Maintainer promotions

Congrats to the following contributors for their promotion:

* Alan Clucas (@Joibel) to Lead in Argo Workflows

* Ryan Umstead (@rumstead) to Approver in Argo CD
* @jswxstw to Reviewer in Argo Workflows
* Regina Voloshin (@reggie-k)  to Reviewer in argo CD

## ⭐  New members

An additional congratulations to the following folks for becoming Argoproj members:

- chengjoey (@chengjoey)
- Siddhesh Ghadi (@svghadi)
- 변재한 (@jaehanbyun)
- Anand Francis Joseph (@anandf)
- Andrii Korotkov (@andrii-korotkov)
- Nitish Kumar (@nitishfy)
- Kunho Lee (@daengdaengLee)
- leehosu (@leehosu)
- Mason Malone (@MasonM)
- nueavv (@nueavv)
- Linghao Su (@linghaoSu)

You all will receive invitations on GitHub to become members of the Argoproj organization.

## 🎓 Alumni

The maintainers document contains a new section for folks who were previously maintainers but have been inactive for at least a year. While not currently active, they deserve continued recognition for their impact on the project!

Closes #321 
Closes #322 
Closes #323 
Closes #324
Closes #326 
Closes #327 
Closes #328 
Closes #329 
Closes #330 
Closes #333 
Closes #334 
Closes #337 
Closes #339 