### PR TITLE
Nominate Revital to sig-marketing

### DIFF
--- a/sigs/sig-marketing/README.md
+++ b/sigs/sig-marketing/README.md
@@ -38,6 +38,7 @@ Participate in our monthly meetings to stay informed and share your ideas. Event
 | Hong Wang | Akuity | hong@akuity.io  |
 | Jenny Blekh | Octopus Deploy | jenny.blekh@octopus.com |
 | Jimil Patel | Intuit | jimil_patel@intuit.com |
+| Revital Barletz | Octopus Deploy | revital.barletz@octopus.com  |
 | Wojtek Cichoń | Akuity | wojtek@akuity.io  |
 
 ## Interested Party


### PR DESCRIPTION
I'd like to nominate @revitalbarletz to sig-marketing.

Revital has a history of contributing to open-source communities most recently growing the Wing OSS community with 1k members in the last year. She's an experienced engineer and already started contributing docs to Argo CD. Over the course of KubeCon / ArgoCon she also helped craft social messages for the conference. I think she'll be a great addition in helping grow our community. 