### PR TITLE
chore: acknowledge we use LFX insights

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -265,7 +265,7 @@ with the current state.
 
 Inactive members are defined as members of one of the Argoproj Organizations
 with no significant contributions within the last 12 months. Contributions are
-measured using the CNCF [DevStats project], GitHub activity history, and other media
+measured using the Linux Foundation's [LFX Insights](https://insights.linuxfoundation.org/project/argo/contributors), GitHub activity history, and other media
 by which a history of contributions can be reliably determined.
 
 If an actively contributing member is accidentally removed this way, they may open an


### PR DESCRIPTION
As noted at October 2025 maintainers meeting and in #394 we use LFX Insights rather than Devstats these days.

I propose we acknowledge that in our membership documents by updating that.

As `membership.md` is linked from  `GOVERNANCE.md` I believe this is a [change to governance](https://github.com/argoproj/argoproj/blob/695e89e25b7bd9284a4682399a5dcf4413f6a189/community/GOVERNANCE.md#changes-to-governance) which requires a 2/3 vote, with voting open for 2 weeks.

Votes are cast by commenting "+1 binding" for [maintainers](https://github.com/argoproj/argoproj/blob/695e89e25b7bd9284a4682399a5dcf4413f6a189/MAINTAINERS.md) or "+1 non-binding" for non-maintainers.