### PR TITLE
docs: Add ppapapetrou76 to sig-security and update affiliations for security SIG members

### DIFF
--- a/sigs/sig-security/README.md
+++ b/sigs/sig-security/README.md
@@ -17,7 +17,7 @@ Argo Project security policy and instructions for reporting issues are available
 ## Secretary
 | Name                                                    | Company   | Email                       |
 |---------------------------------------------------------|-----------|-----------------------------|
-| [Pavel Kostohrys](https://github.com/pasha-codefresh)   | Codefresh |                             |
+| [Pavel Kostohrys](https://github.com/pasha-codefresh)   | Octopus Deploy |                             |
 
 ## Members
 | Name                                                    | Company   | Email                       |


### PR DESCRIPTION
Knocking a couple of things out in one PR

- Add @ppapapetrou76 to sig-security
- Update @christianh814 affiliation to Cisco, and drop old email, he may want to add a new one. 
- Update @todaywasawesome @pasha-codefresh and @cvandal affiliation to Octopus Deploy