### PR TITLE
chore: define inactive reviewers

### DIFF
--- a/community/membership.md
+++ b/community/membership.md
@@ -268,6 +268,10 @@ with no significant contributions within the last 12 months. Contributions are
 measured using the Linux Foundation's [LFX Insights](https://insights.linuxfoundation.org/project/argo/contributors), GitHub activity history, and other media
 by which a history of contributions can be reliably determined.
 
+Inactive approvers are defined as members of one of the Argoproj Organizations 
+who have not reviewed any pull requests in their main repository within the last 
+12 months.
+
 If an actively contributing member is accidentally removed this way, they may open an
 issue to quickly be re-instated.
 

--- a/community/membership.md
+++ b/community/membership.md
@@ -268,7 +268,7 @@ with no significant contributions within the last 12 months. Contributions are
 measured using the Linux Foundation's [LFX Insights](https://insights.linuxfoundation.org/project/argo/contributors), GitHub activity history, and other media
 by which a history of contributions can be reliably determined.
 
-Inactive approvers are defined as members of one of the Argoproj Organizations 
+Inactive approvers are defined as members who hold an approver role in one of the Argoproj subprojects 
 who have not reviewed any pull requests in their main repository within the last 
 12 months.
 


### PR DESCRIPTION
This iterates on https://github.com/argoproj/argoproj/pull/244 and narrows its scope.

Instead of requiring that reviewers have PR reviews within the last 12 months, this only requires that _approvers_ have reviews within the last 12 months.

This change is meant to accommodate folks who in the past were added as Reviewers and continue to be active maintainers but who do not do code reviews.

By focusing on fine-tuning the Approver role, we can avoid entirely removing maintainer status from people who are active in the community, while still respecting the principle of least privilege when those maintainers are not actively reviewing and merging PRs.