### PR TITLE
docs: security by GHSA

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,20 +25,18 @@ respective code repositories:
 
 ### Argoproj Labs
 
-The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and may have different security practices than the four Argo sub-projects. All Labs projects are required to have a `SECURITY.md` in the root of their repository documenting their security policies as well as listing security contacts for reporting vulnerabilities. 
+The [Argoproj Labs](https://github.com/argoproj-labs) projects are a set community maintained projects (housed under a single GitHub organization) and do not fall under the scope of CNCF. They are independently maintained and typically have a separate set of members and maintainers from the [Argoproj maintainers](MAINTAINERS.md). Labs project have  **_not_** undergone the same security reviews, membership requirements, and may have different security practices than the four Argo sub-projects. All Labs projects are required to have a `SECURITY.md` in the root of their repository documenting their security policies as well as listing security contacts for reporting vulnerabilities.
 
 ## Reporting Vulnerabilities
 
-In general, we kindly ask you for responsible disclosure of any security
-vulnerabilities you may have found in one of our projects. Please do not create
-a GitHub issue, but instead contact us via e-mail at the following address:
+In general, we kindly ask you for responsible disclosure of any security vulnerabilities you may have found in one of our projects.
+Please do not create a GitHub issue, but instead open a draft GitHub security advisory: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/creating-a-repository-security-advisory
 
-* cncf-argo-security@lists.cncf.io
+We no longer accept security disclosure by email.
 
 For reporting vulnerabilities to projects under Argoproj Labs, please visit the project's `SECURITY.md` policy to reach the correct contacts.
 
-We also kindly ask you to allow us some time for analysing the report and react
-on it. We will get in contact with you as soon as possible.
+We also kindly ask you to allow us some time for analysing the report and react on it. We will get in contact with you as soon as possible.
 
 ## Internet Bug Bounty collaboration
 


### PR DESCRIPTION
As discussed in #argo-security in slack and at the sig-security meeting on the 10th Feb 2026 we would like to switch to only using GHSA for security disclosure.

The problems with email disclosure:
* There is no dashboard, it's easy for emails to get lost in the noise
* We've had exact duplicates of issues submitted to both email and GHSA, and discussion and closure of the GHSA has not resulted in closure of the email thread. I don't know if this resulted in a bounty being paid.
* Huntr advertise "The world's first bug bounty platform for AI/ML" - and is submitting email reports.
* Email has a very low friction and is very automate-able. "Throw enough disclosures over the email wall and hope that some get through so that I get a bounty".

We have considered that filing a GHSA requires a sign-up to a third party service (Github) and accept that this is worth the possible loss of some security disclosures.

Each project will also need to update their own SECURITY.md file if this is accepted.

Currently argo-events does not have GHSA enabled, and this would