### PR TITLE
Remove Ed Lee from sig-security

### DIFF
--- a/sigs/sig-security/README.md
+++ b/sigs/sig-security/README.md
@@ -28,7 +28,6 @@ Argo Project security policy and instructions for reporting issues are available
 | [Christian Hernandez](https://github.com/christianh814) | Cisco    |          |
 | [Chris van Dal](https://github.com/cvandal)             | Octopus Deploy |                             |
 | [Dan Garfield](https://github.com/todaywasawesome)      | Octopus Deploy | dan.garfield@octopus.com            |
-| [Ed Lee](https://github.com/edlee2121)                  | Intuit    |                             |
 | [Eugene Dudin](https://github.com/dudinea)              | Octopus Deploy    |                             |
 | [Henrik Blixt](https://github.com/hblixt)               | Intuit    | Henrik_Blixt@intuit.com     |
 | [Jann Fischer](https://github.com/jannfis)              | Red Hat   | jfischer@redhat.com         |


### PR DESCRIPTION
A big thanks to Ed for all his contributions. He isn't active in sig-security anymore and it's important we keep this group limited to active contributors only. 