### PR TITLE
Argoproj promotions/membership

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,23 +7,23 @@
 ## Maintainers
 
 | Maintainer                | GitHub ID                                               | Project Roles                                                                | Affiliation                                          |
-| ------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------- |
+|---------------------------|---------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------|
 | Rohit Agrawal             | [agrawroh](https://github.com/agrawroh)                 | Reviewer - Rollouts                                                          | [Databricks](https://databricks.com/)                |
 | Aikawa                    | [yu-croco](https://github.com/yu-croco)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows                       |                                                      |
 | Zach Aller                | [zachaller](https://github.com/zachaller)               | Lead - Rollouts <br/>Reviewer - CD                                           | [Intuit](https://www.github.com/intuit/)             |
 | Leonardo Luz Almeida      | [leoluz](https://github.com/leoluz)                     | Approver - CD, Rollouts                                                      | [Intuit](https://www.github.com/intuit/)             |
-| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Approver - Workflows                                                         | [Intuit](https://www.github.com/intuit/)             |
+| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)         | Reviewer - Workflows                                                         | [Intuit](https://www.github.com/intuit/)             |
 | Marko Bevc                | [mbevc1](https://github.com/mbevc1)                     | Approver(helm-chart) - CD                                                    | [The Scale Factory](https://github.com/scalefactory) |
 | Henrik Blixt              | [hblixt](https://github.com/hblixt)                     | Reviewer                                                                     | [Intuit](https://www.github.com/intuit/)             |
 | Keith Chong               | [keithchong](https://github.com/keithchong)             | Approver - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
 | Jaewoo Choi               | [choejwoo](https://github.com/choejwoo)                 | Reviewer - CD                                                                | Hyundai-Autoever                                     |
 | Alan Clucas               | [Joibel](https://github.com/Joibel)                     | Lead - Workflows                                                             | [Pipekit](https://www.pipekit.io/)                   |
-| Alex Collins              | [alexec](https://github.com/alexec)                     | Approver - Workflows <br/>Approver - CD                                      | [Intuit](https://www.github.com/intuit/)             |
-| Tim Collins               | [tico24](https://github.com/tico24)                     | Approver(helm-chart) - CD, Events, Workflows<br />Reviewer(docs) - Workflows | Independent                                          |
+| Alex Collins              | [alexec](https://github.com/alexec)                     | Reviewer - Workflows <br/>Reviewer - CD                                      | [Intuit](https://www.github.com/intuit/)             |
+| Tim Collins               | [tico24](https://github.com/tico24)                     | Approver(helm-chart) - CD, Events, Workflows<br />Approver(docs) - Workflows | Independent                                          |
 | Michael Crenshaw          | [crenshaw-dev](https://github.com/crenshaw-dev)         | Lead - CD                                                                    | [Intuit](https://www.github.com/intuit/)             |
 | Soumya Ghosh Dastidar     | [gdsoumya](https://github.com/gdsoumya)                 | Approver - CD                                                                | [Akuity](https://akuity.io/)                         |
-| Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Approver(helm-chart) - CD, Events                                            | Independent                                          |
-| Eugene Dudin              | [dudinea](https://github.com/dudinea)                   | Reviewer - CD                                                                | [Octopus Deploy](https://octopus.com/)               |
+| Petr Drastil              | [pdrastil](https://github.com/pdrastil)                 | Reviewer(helm-chart) - CD, Events                                            | Independent                                          |
+| Eugene Dudin              | [dudinea](https://github.com/dudinea)                   | Approver(ci,docs) - CD                                                       | [Octopus Deploy](https://octopus.com/)               |
 | Alex Eftimie              | [alexef](https://github.com/alexef)                     | Reviewer - CD                                                                | [GetYourGuide](https://www.getyourguide.com/)        |
 | Jann Fischer              | [jannfis](https://github.com/jannfis)                   | Approver - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
 | Dan Garfield              | [todaywasawesome](https://github.com/todaywasawesome)   | Approver(docs) - CD                                                          | [Codefresh](https://www.github.com/codefresh/)       |
@@ -31,11 +31,11 @@
 | Christian Hernandez       | [christianh814](https://github.com/christianh814)       | Reviewer(docs) - CD                                                          | [Akuity](https://akuity.io/)                         |
 | Peter Jiang               | [pjiang-dev](https://github.com/pjiang-dev)             | Approver(docs) - CD                                                          | [Intuit](https://www.intuit.com/)                    |
 | Yucong Wang               | [jswxstw](https://github.com/jswxstw)                   | Reviewer - Workflows                                                         | Independent                                          |
-| Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Reviewer - Rollouts                                                          | [Codefresh](https://www.github.com/codefresh/)       |
+| Kostis Kapelonis          | [kostis-codefresh](https://github.com/kostis-codefresh) | Approver(ci,docs) - Rollouts                                                 | [Codefresh](https://www.github.com/codefresh/)       |
 | Andrii Korotkov           | [andrii-korotkov](https://github.com/andrii-korotkov)   | Reviewer - CD                                                                | [Verkada](https://www.verkada.com/)                  |
 | Pasha Kostohrys           | [pasha-codefresh](https://github.com/pasha-codefresh)   | Approver - CD                                                                | [Codefresh](https://www.github.com/codefresh/)       |
 | Nitish Kumar              | [nitishfy](https://github.com/nitishfy)                 | Approver(cli,docs) - CD                                                      | [Akuity](https://akuity.io/)                         |
-| Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Approver - Workflows, Events                                                 | [Intuit](https://www.github.com/intuit/)             |
+| Ed Lee                    | [edlee2121](https://github.com/edlee2121)               | Reviewer - Workflows, Events                                                 | [Intuit](https://www.github.com/intuit/)             |
 | Vlad Losev                | [vladlosev](https://github.com/vladlosev)               | Approver(helm-chart) - CD                                                    | [Sage Intacct](https://github.com/intacct)           |
 | Mason Malone              | [MasonM](https://github.com/MasonM)                     | Approver - Workflows                                                         | [Adobe](https://www.adobe.com/)                      |
 | Alexy Mantha              | [alexymantha](https://github.com/alexymantha)           | Reviewer - CD                                                                | GoTo                                                 |
@@ -43,12 +43,13 @@
 | Alexander Matyushentsev   | [alexmt](https://github.com/alexmt)                     | Lead - CD <br/>Approver - Workflows                                          | [Akuity](https://akuity.io/)                         |
 | Marco Maurer              | [mkilchhofer](https://github.com/mkilchhofer)           | Approver(helm-chart) - CD, Events, Rollouts, Workflows                       | [Swiss Post](https://post.ch/)                       |
 | Jason Meridth             | [jmeridth](https://github.com/jmeridth)                 | Approver(helm-chart) - CD, Events, Rollouts, Workflows                       | [Chainguard](https://chainguard.dev/)                |
+| Oliver Gondža             | [olivergondza](https://github.com/olivergondza)         | Reviewer - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
 | Papapetrou Patroklos      | [ppapapetrou76](https://github.com/ppapapetrou76)       | Approver(cli,docs) - CD                                                      | [Octopus Deploy](https://octopus.com/)               |
 | Blake Pettersson          | [blakepettersson](https://github.com/blakepettersson)   | Approver - CD                                                                | [Akuity](https://akuity.io/)                         |
 | Kanika Rana               | [ranakan19](https://github.com/ranakan19)               | Reviewer - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
 | Eduardo Rodrigues         | [eduardodbr](https://github.com/eduardodbr)             | Reviewer - Events, Workflows                                                 |                                                      |
 | Ishita Sequeira           | [ishitasequeira](https://github.com/ishitasequeira)     | Approver - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
-| Ashutosh Singh            | [ashutosh16](https://github.com/ashutosh16)             | Approver(docs) - CD                                                          | [Intuit](https://www.github.com/intuit/)             |
+| Ashutosh Singh            | [ashutosh16](https://github.com/ashutosh16)             | Reviewer(docs) - CD                                                          | [Intuit](https://www.github.com/intuit/)             |
 | Linghao Su                | [linghaoSu](https://github.com/linghaoSu)               | Reviewer - CD                                                                | [DaoCloud](https://daocloud.io)                      |
 | Isitha Subasinghe         | [isubasinghe](https://github.com/isubasinghe)           | Approver - Workflows                                                         | [Pipekit](https://pipekit.io/)                       |
 | Jesse Suen                | [jessesuen](https://github.com/jessesuen)               | Lead - Rollouts <br/>Approver - CD, Workflows, Events                        | [Akuity](https://akuity.io/)                         |
@@ -60,15 +61,15 @@
 | Regina Voloshin           | [reggie-k](https://github.com/reggie-k)                 | Approver - CD                                                                | [Codefresh](https://www.github.com/codefresh/)       |
 | Derek Wang                | [whynowy](https://github.com/whynowy)                   | Lead - Events                                                                | [Intuit](https://www.github.com/intuit/)             |
 | Hong Wang                 | [wanghong230](https://github.com/wanghong230)           | Reviewer                                                                     | [Akuity](https://akuity.io/)                         |
-| Jonathan West             | [jgwest](https://github.com/jgwest)                     | Approver - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
-| Jonathan Winters          | [jwinters01](https://github.com/jwinters01)             | Reviewer - CD                                                                | [Intuit](https://www.github.com/intuit/)             |
+| Jonathan West             | [jgwest](https://github.com/jgwest)                     | Reviewer - CD                                                                | [Red Hat](https://www.redhat.com/)                   |
+| Jonathan Winters          | [jwinters01](https://github.com/jwinters01)             | Approver(ui) - CD                                                            | [Intuit](https://www.github.com/intuit/)             |
 | Tianchu Zhao              | [tczhao](https://github.com/tczhao)                     | Approver - Workflows                                                         | [Atlan](https://atlan.com/)                          |
 | William Van Hevelingen    | [blkperl](https://github.com/blkperl)                   | Reviewer - Workflows                                                         | [Acquia](https://github.com/acquia)                  |
 
 ## Alumni
 
 | Alumni                  | GitHub ID                                               | Project Roles                | Affiliation                                     |
-| ----------------------- | ------------------------------------------------------- | ---------------------------- | ----------------------------------------------- |
+|-------------------------|---------------------------------------------------------|------------------------------|-------------------------------------------------|
 | Chetan Banavikalmutt    | [chetan-rns](https://github.com/chetan-rns)             | Reviewer - CD                | [Red Hat](https://www.redhat.com/)              |
 | Simon Behar             | [simster7](https://github.com/simster7)                 | Approver - Workflows         | [AirBnB](https://www.github.com/airbnb/)        |
 | Shoubhik Bose           | [sbose78](https://github.com/sbose78)                   | Reviewer                     | [Red Hat](https://www.redhat.com/)              |

--- a/OWNERS
+++ b/OWNERS
@@ -9,24 +9,22 @@ owners:
 
 approvers:
 - agaudreault
-- alexec
 - gdsoumya
 - ishitasequeira
 - isubasinghe
 - jannfis
-- jgwest
 - juliev0
 - keithchong
 - leoluz
 - mayzhang2000
 - pasha-codefresh
 - rbreeze
-- sarabala1979
 - tczhao
 
 reviewers:
 - 34fathombelow
 - agrawroh
+- alexec
 - alexef
 - ashutosh16
 - blakepettersson
@@ -34,14 +32,21 @@ reviewers:
 - chetan-rns
 - ciiay
 - daniel-codefresh
+- dudinea
+- edlee2121
 - harikrongali
 - hblixt
+- jgwest
 - jswxstw
+- jwinters01
 - kostis-codefresh
 - nitishfy
+- olivergondza
+- pdrastil
 - reginapizza
 - reggie-k
 - rumstead
+- sarabala1979
 - saumeya
 - sbose78
 - shuangkun


### PR DESCRIPTION
# Argoproj promotions/membership

Every quarter, the Argoproj maintainers review requests for project membership and promotions ([read about the roles here](https://github.com/argoproj/argoproj/blob/master/community/membership.md)). The changes below recognize the efforts and commitment to the project by these people. Thank you so much!

## 🚀 Maintainer promotions

Congrats to the following contributors for their promotions:

* Oliver Gondža (@olivergondza) to Reviewer in Argo CD
* Jonathan Winters (@jwinters01) to Approver(ui) in Argo CD
* Eugene Dudin (@dudinea) to Approver(ci,docs) in Argo CD
* Tim Collins (@tico24) to Approver(docs) in Argo Workflows
* Kostis Kapelonis (@kostis-codefresh) to Approver(ci,docs) in Argo Rollouts

## ⭐ New members

An additional congratulations to the following folks for becoming Argoproj members:

* thevilledev (@thevilledev)
* adityaraj178 (@adityaraj178)
* Hariharasuthan99 (@Hariharasuthan99)
* Kevinjoeharris (@Kevinjoeharris)
* yugannkt (@yugannkt)
* cjcocokrisp (@cjcocokrisp)

You all will receive invitations on GitHub to become members of the Argoproj organization.

## 📋 Maintainer Approver -> Reviewer moves

As part of the maintainer activity review, the following contributors are moving from full approver to reviewer (same project scope):

* Alex Collins (@alexec) to Reviewer in Argo CD and Argo Workflows
* Ashutosh Singh (@ashutosh16) to Reviewer(docs) in Argo CD
* Ed Lee (@edlee2121) to Reviewer in Argo Workflows and Argo Events
* Jonathan West (@jgwest) to Reviewer in Argo CD
* Petr Drastil (@pdrastil) to Reviewer(helm-chart) in Argo CD and Argo Events
* Saravanan Balasubramanian (@sarabala1979) to Reviewer in Argo Workflows

Closes #435  
Closes #436  
Closes #437  
Closes #438  
Closes #440  
Closes #441  
Closes #442  
Closes #450  
Closes #451  
Closes #453  
Closes #454